### PR TITLE
e2e: inline fixture expectations in upload tests and prefer env token in CLI

### DIFF
--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -73,6 +73,11 @@ export function writeConfig(config: Config): void {
  * Uses environment-specific account names
  */
 export function getToken(): string | null {
+  const envToken = process.env.AGENTLOGS_AUTH_TOKEN?.trim();
+  if (envToken) {
+    return envToken;
+  }
+
   try {
     const config = readConfig();
     if (!config.user?.email) {

--- a/packages/e2e/tests/upload.e2e.ts
+++ b/packages/e2e/tests/upload.e2e.ts
@@ -1,0 +1,123 @@
+import { test, expect } from "@playwright/test";
+import { $ } from "bun";
+import path from "path";
+
+const ROOT_DIR = path.resolve(import.meta.dirname!, "../../..");
+const TEST_AUTH_TOKEN = "test-session-token";
+const SERVER_URL = "http://localhost:3009";
+
+type FixtureCase = {
+  cwd: string;
+  expectedSnippet: string;
+  fixturePath: string;
+  uploadCommand: string;
+};
+
+async function uploadFixtureTranscript(fixture: FixtureCase): Promise<string> {
+  return await $`bun agentlogs ${fixture.uploadCommand} upload ${fixture.fixturePath}`
+    .cwd(ROOT_DIR)
+    .env({
+      ...process.env,
+      SERVER_URL,
+      AGENTLOGS_AUTH_TOKEN: TEST_AUTH_TOKEN,
+    })
+    .text();
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+async function assertTranscriptInUi(page: Parameters<typeof test>[0]["page"], fixture: FixtureCase) {
+  await page.goto("/app");
+
+  const cwdRow = page.getByRole("row", { name: new RegExp(escapeRegex(fixture.cwd)) });
+  await expect(cwdRow).toBeVisible();
+  await cwdRow.getByRole("link", { name: "View" }).click();
+
+  const previewRow = page.getByRole("row", { name: new RegExp(escapeRegex(fixture.expectedSnippet)) });
+  await expect(previewRow).toBeVisible();
+  await previewRow.getByRole("link", { name: "View" }).click();
+
+  await expect(page.getByText(fixture.expectedSnippet)).toBeVisible();
+}
+
+test.describe("CLI Upload", () => {
+  test("uploads claudecode crud fixture and shows it in the UI", async ({ page }) => {
+    const fixture = {
+      cwd: "/Users/philipp/dev/vibeinsights/fixtures/claudecode",
+      expectedSnippet: "create a file `JOKE.md` with a ranom joke",
+      fixturePath: path.join(ROOT_DIR, "fixtures/claudecode/crud.jsonl"),
+      uploadCommand: "claudecode",
+    } satisfies FixtureCase;
+    const output = await uploadFixtureTranscript(fixture);
+    expect(output).toContain("Upload successful");
+
+    await assertTranscriptInUi(page, fixture);
+  });
+
+  test("uploads claudecode compact fixture and shows it in the UI", async ({ page }) => {
+    const fixture = {
+      cwd: "/Users/philipp/dev/studio",
+      expectedSnippet: "how are you doing",
+      fixturePath: path.join(ROOT_DIR, "fixtures/claudecode/compact.jsonl"),
+      uploadCommand: "claudecode",
+    } satisfies FixtureCase;
+    const output = await uploadFixtureTranscript(fixture);
+    expect(output).toContain("Upload successful");
+
+    await assertTranscriptInUi(page, fixture);
+  });
+
+  test("uploads claudecode images fixture and shows it in the UI", async ({ page }) => {
+    const fixture = {
+      cwd: "/Users/philipp/dev/vibeinsights",
+      expectedSnippet: "go to google.com, make a screenshoot, look at it, and tell me what you think",
+      fixturePath: path.join(ROOT_DIR, "fixtures/claudecode/images.jsonl"),
+      uploadCommand: "claudecode",
+    } satisfies FixtureCase;
+    const output = await uploadFixtureTranscript(fixture);
+    expect(output).toContain("Upload successful");
+
+    await assertTranscriptInUi(page, fixture);
+  });
+
+  test("uploads claudecode subagent fixture and shows it in the UI", async ({ page }) => {
+    const fixture = {
+      cwd: "/Users/philipp/dev/studio",
+      expectedSnippet: "ask a subagent how he's doing",
+      fixturePath: path.join(ROOT_DIR, "fixtures/claudecode/subagent.jsonl"),
+      uploadCommand: "claudecode",
+    } satisfies FixtureCase;
+    const output = await uploadFixtureTranscript(fixture);
+    expect(output).toContain("Upload successful");
+
+    await assertTranscriptInUi(page, fixture);
+  });
+
+  test("uploads claudecode todos fixture and shows it in the UI", async ({ page }) => {
+    const fixture = {
+      cwd: "/Users/philipp/dev/vibeinsights/fixtures/claudecode",
+      expectedSnippet: "create a todo list with 3 items",
+      fixturePath: path.join(ROOT_DIR, "fixtures/claudecode/todos.jsonl"),
+      uploadCommand: "claudecode",
+    } satisfies FixtureCase;
+    const output = await uploadFixtureTranscript(fixture);
+    expect(output).toContain("Upload successful");
+
+    await assertTranscriptInUi(page, fixture);
+  });
+
+  test("uploads codex crud fixture and shows it in the UI", async ({ page }) => {
+    const fixture = {
+      cwd: "/Users/philipp/dev/vibeinsights/fixtures",
+      expectedSnippet: "create a file `JOKE.md` with a random joke",
+      fixturePath: path.join(ROOT_DIR, "fixtures/codex/crud.jsonl"),
+      uploadCommand: "codex",
+    } satisfies FixtureCase;
+    const output = await uploadFixtureTranscript(fixture);
+    expect(output).toContain("Upload successful");
+
+    await assertTranscriptInUi(page, fixture);
+  });
+});


### PR DESCRIPTION
### Motivation
- Make the upload e2e tests easier to read and maintain by inlining each fixture's expectations directly in the corresponding test.
- Reduce indirection and accidental coupling from top-level fixture constants.
- Allow CI and local runs to authenticate the CLI using an environment-provided token by preferring `AGENTLOGS_AUTH_TOKEN`.
- Keep exercising the full upload flow (CLI -> server -> UI) while simplifying assertions.

### Description
- Updated `packages/e2e/tests/upload.e2e.ts` to inline fixture objects inside each `test(...)` and removed the previous top-level fixture constants, while keeping shared helpers `uploadFixtureTranscript` and `assertTranscriptInUi`.
- Added/retained a `FixtureCase` type and used `satisfies FixtureCase` for the inlined fixtures to preserve typing.
- Updated CLI config in `packages/cli/src/config.ts` so `getToken()` first returns `process.env.AGENTLOGS_AUTH_TOKEN` (if set) and otherwise falls back to the OS keychain lookup.
- Tests still assert the CLI output contains `Upload successful` and that the expected snippet is visible in the UI via Playwright selectors.

### Testing
- No automated tests were run for this change in this environment.
- Previous attempts in this environment to run `bun test:e2e` were unsuccessful due to missing dependencies (registry 403 / Playwright not installed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696575e22be0833380f3b670b5a9c903)