### PR TITLE
Scope app under /app and rename /transcripts

### DIFF
--- a/packages/opencode/README.md
+++ b/packages/opencode/README.md
@@ -83,7 +83,7 @@ Example enhanced commit:
 ```
 feat: add user authentication
 
-Transcript: https://agentlogs.ai/transcripts/abc123
+Transcript: https://agentlogs.ai/app/logs/abc123
 ```
 
 ## Plugin Events

--- a/packages/opencode/src/upload.ts
+++ b/packages/opencode/src/upload.ts
@@ -69,7 +69,7 @@ export async function uploadOpenCodeTranscript(params: UploadParams): Promise<Up
       return {
         success: true,
         transcriptId: result.transcriptId,
-        transcriptUrl: `${baseUrl}/transcripts/${result.transcriptId}`,
+        transcriptUrl: `${baseUrl}/app/logs/${result.transcriptId}`,
       };
     }
 
@@ -90,5 +90,5 @@ export async function uploadOpenCodeTranscript(params: UploadParams): Promise<Up
  */
 export function buildTranscriptUrl(transcriptId: string, serverUrl?: string): string {
   const baseUrl = serverUrl ?? process.env.VI_SERVER_URL ?? "https://agentlogs.ai";
-  return `${baseUrl}/transcripts/${transcriptId}`;
+  return `${baseUrl}/app/logs/${transcriptId}`;
 }

--- a/packages/web/src/routeTree.gen.ts
+++ b/packages/web/src/routeTree.gen.ts
@@ -15,15 +15,15 @@ import { Route as AuthSplatRouteImport } from './routes/auth.$'
 import { Route as ApiTranscriptsRouteImport } from './routes/api/transcripts'
 import { Route as ApiIngestRouteImport } from './routes/api/ingest'
 import { Route as ApiCommitTrackRouteImport } from './routes/api/commit-track'
-import { Route as AppDeviceRouteImport } from './routes/_app/device'
-import { Route as AppAppRouteImport } from './routes/_app/app'
+import { Route as AppAppIndexRouteImport } from './routes/_app/app/index'
 import { Route as ApiTranscriptsClearRouteImport } from './routes/api/transcripts/clear'
 import { Route as ApiBlobsSha256RouteImport } from './routes/api/blobs.$sha256'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth.$'
-import { Route as AppTranscriptsIdRouteImport } from './routes/_app/transcripts.$id'
 import { Route as AppSSessionIdRouteImport } from './routes/_app/s.$sessionId'
-import { Route as AppReposIdRouteImport } from './routes/_app/repos.$id'
-import { Route as AppPrivateCwdRouteImport } from './routes/_app/private.$cwd'
+import { Route as AppAppDeviceRouteImport } from './routes/_app/app/device'
+import { Route as AppAppReposIdRouteImport } from './routes/_app/app/repos.$id'
+import { Route as AppAppPrivateCwdRouteImport } from './routes/_app/app/private.$cwd'
+import { Route as AppAppLogsIdRouteImport } from './routes/_app/app/logs.$id'
 
 const AppRoute = AppRouteImport.update({
   id: '/_app',
@@ -54,14 +54,9 @@ const ApiCommitTrackRoute = ApiCommitTrackRouteImport.update({
   path: '/api/commit-track',
   getParentRoute: () => rootRouteImport,
 } as any)
-const AppDeviceRoute = AppDeviceRouteImport.update({
-  id: '/device',
-  path: '/device',
-  getParentRoute: () => AppRoute,
-} as any)
-const AppAppRoute = AppAppRouteImport.update({
-  id: '/app',
-  path: '/app',
+const AppAppIndexRoute = AppAppIndexRouteImport.update({
+  id: '/app/',
+  path: '/app/',
   getParentRoute: () => AppRoute,
 } as any)
 const ApiTranscriptsClearRoute = ApiTranscriptsClearRouteImport.update({
@@ -79,127 +74,132 @@ const ApiAuthSplatRoute = ApiAuthSplatRouteImport.update({
   path: '/api/auth/$',
   getParentRoute: () => rootRouteImport,
 } as any)
-const AppTranscriptsIdRoute = AppTranscriptsIdRouteImport.update({
-  id: '/transcripts/$id',
-  path: '/transcripts/$id',
-  getParentRoute: () => AppRoute,
-} as any)
 const AppSSessionIdRoute = AppSSessionIdRouteImport.update({
   id: '/s/$sessionId',
   path: '/s/$sessionId',
   getParentRoute: () => AppRoute,
 } as any)
-const AppReposIdRoute = AppReposIdRouteImport.update({
-  id: '/repos/$id',
-  path: '/repos/$id',
+const AppAppDeviceRoute = AppAppDeviceRouteImport.update({
+  id: '/app/device',
+  path: '/app/device',
   getParentRoute: () => AppRoute,
 } as any)
-const AppPrivateCwdRoute = AppPrivateCwdRouteImport.update({
-  id: '/private/$cwd',
-  path: '/private/$cwd',
+const AppAppReposIdRoute = AppAppReposIdRouteImport.update({
+  id: '/app/repos/$id',
+  path: '/app/repos/$id',
+  getParentRoute: () => AppRoute,
+} as any)
+const AppAppPrivateCwdRoute = AppAppPrivateCwdRouteImport.update({
+  id: '/app/private/$cwd',
+  path: '/app/private/$cwd',
+  getParentRoute: () => AppRoute,
+} as any)
+const AppAppLogsIdRoute = AppAppLogsIdRouteImport.update({
+  id: '/app/logs/$id',
+  path: '/app/logs/$id',
   getParentRoute: () => AppRoute,
 } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
-  '/app': typeof AppAppRoute
-  '/device': typeof AppDeviceRoute
   '/api/commit-track': typeof ApiCommitTrackRoute
   '/api/ingest': typeof ApiIngestRoute
   '/api/transcripts': typeof ApiTranscriptsRouteWithChildren
   '/auth/$': typeof AuthSplatRoute
-  '/private/$cwd': typeof AppPrivateCwdRoute
-  '/repos/$id': typeof AppReposIdRoute
+  '/app/device': typeof AppAppDeviceRoute
   '/s/$sessionId': typeof AppSSessionIdRoute
-  '/transcripts/$id': typeof AppTranscriptsIdRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/blobs/$sha256': typeof ApiBlobsSha256Route
   '/api/transcripts/clear': typeof ApiTranscriptsClearRoute
+  '/app': typeof AppAppIndexRoute
+  '/app/logs/$id': typeof AppAppLogsIdRoute
+  '/app/private/$cwd': typeof AppAppPrivateCwdRoute
+  '/app/repos/$id': typeof AppAppReposIdRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
-  '/app': typeof AppAppRoute
-  '/device': typeof AppDeviceRoute
   '/api/commit-track': typeof ApiCommitTrackRoute
   '/api/ingest': typeof ApiIngestRoute
   '/api/transcripts': typeof ApiTranscriptsRouteWithChildren
   '/auth/$': typeof AuthSplatRoute
-  '/private/$cwd': typeof AppPrivateCwdRoute
-  '/repos/$id': typeof AppReposIdRoute
+  '/app/device': typeof AppAppDeviceRoute
   '/s/$sessionId': typeof AppSSessionIdRoute
-  '/transcripts/$id': typeof AppTranscriptsIdRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/blobs/$sha256': typeof ApiBlobsSha256Route
   '/api/transcripts/clear': typeof ApiTranscriptsClearRoute
+  '/app': typeof AppAppIndexRoute
+  '/app/logs/$id': typeof AppAppLogsIdRoute
+  '/app/private/$cwd': typeof AppAppPrivateCwdRoute
+  '/app/repos/$id': typeof AppAppReposIdRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/_app': typeof AppRouteWithChildren
-  '/_app/app': typeof AppAppRoute
-  '/_app/device': typeof AppDeviceRoute
   '/api/commit-track': typeof ApiCommitTrackRoute
   '/api/ingest': typeof ApiIngestRoute
   '/api/transcripts': typeof ApiTranscriptsRouteWithChildren
   '/auth/$': typeof AuthSplatRoute
-  '/_app/private/$cwd': typeof AppPrivateCwdRoute
-  '/_app/repos/$id': typeof AppReposIdRoute
+  '/_app/app/device': typeof AppAppDeviceRoute
   '/_app/s/$sessionId': typeof AppSSessionIdRoute
-  '/_app/transcripts/$id': typeof AppTranscriptsIdRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/blobs/$sha256': typeof ApiBlobsSha256Route
   '/api/transcripts/clear': typeof ApiTranscriptsClearRoute
+  '/_app/app/': typeof AppAppIndexRoute
+  '/_app/app/logs/$id': typeof AppAppLogsIdRoute
+  '/_app/app/private/$cwd': typeof AppAppPrivateCwdRoute
+  '/_app/app/repos/$id': typeof AppAppReposIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
-    | '/app'
-    | '/device'
     | '/api/commit-track'
     | '/api/ingest'
     | '/api/transcripts'
     | '/auth/$'
-    | '/private/$cwd'
-    | '/repos/$id'
+    | '/app/device'
     | '/s/$sessionId'
-    | '/transcripts/$id'
     | '/api/auth/$'
     | '/api/blobs/$sha256'
     | '/api/transcripts/clear'
+    | '/app'
+    | '/app/logs/$id'
+    | '/app/private/$cwd'
+    | '/app/repos/$id'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
-    | '/app'
-    | '/device'
     | '/api/commit-track'
     | '/api/ingest'
     | '/api/transcripts'
     | '/auth/$'
-    | '/private/$cwd'
-    | '/repos/$id'
+    | '/app/device'
     | '/s/$sessionId'
-    | '/transcripts/$id'
     | '/api/auth/$'
     | '/api/blobs/$sha256'
     | '/api/transcripts/clear'
+    | '/app'
+    | '/app/logs/$id'
+    | '/app/private/$cwd'
+    | '/app/repos/$id'
   id:
     | '__root__'
     | '/'
     | '/_app'
-    | '/_app/app'
-    | '/_app/device'
     | '/api/commit-track'
     | '/api/ingest'
     | '/api/transcripts'
     | '/auth/$'
-    | '/_app/private/$cwd'
-    | '/_app/repos/$id'
+    | '/_app/app/device'
     | '/_app/s/$sessionId'
-    | '/_app/transcripts/$id'
     | '/api/auth/$'
     | '/api/blobs/$sha256'
     | '/api/transcripts/clear'
+    | '/_app/app/'
+    | '/_app/app/logs/$id'
+    | '/_app/app/private/$cwd'
+    | '/_app/app/repos/$id'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -257,18 +257,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiCommitTrackRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/_app/device': {
-      id: '/_app/device'
-      path: '/device'
-      fullPath: '/device'
-      preLoaderRoute: typeof AppDeviceRouteImport
-      parentRoute: typeof AppRoute
-    }
-    '/_app/app': {
-      id: '/_app/app'
+    '/_app/app/': {
+      id: '/_app/app/'
       path: '/app'
       fullPath: '/app'
-      preLoaderRoute: typeof AppAppRouteImport
+      preLoaderRoute: typeof AppAppIndexRouteImport
       parentRoute: typeof AppRoute
     }
     '/api/transcripts/clear': {
@@ -292,13 +285,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiAuthSplatRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/_app/transcripts/$id': {
-      id: '/_app/transcripts/$id'
-      path: '/transcripts/$id'
-      fullPath: '/transcripts/$id'
-      preLoaderRoute: typeof AppTranscriptsIdRouteImport
-      parentRoute: typeof AppRoute
-    }
     '/_app/s/$sessionId': {
       id: '/_app/s/$sessionId'
       path: '/s/$sessionId'
@@ -306,39 +292,53 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppSSessionIdRouteImport
       parentRoute: typeof AppRoute
     }
-    '/_app/repos/$id': {
-      id: '/_app/repos/$id'
-      path: '/repos/$id'
-      fullPath: '/repos/$id'
-      preLoaderRoute: typeof AppReposIdRouteImport
+    '/_app/app/device': {
+      id: '/_app/app/device'
+      path: '/app/device'
+      fullPath: '/app/device'
+      preLoaderRoute: typeof AppAppDeviceRouteImport
       parentRoute: typeof AppRoute
     }
-    '/_app/private/$cwd': {
-      id: '/_app/private/$cwd'
-      path: '/private/$cwd'
-      fullPath: '/private/$cwd'
-      preLoaderRoute: typeof AppPrivateCwdRouteImport
+    '/_app/app/repos/$id': {
+      id: '/_app/app/repos/$id'
+      path: '/app/repos/$id'
+      fullPath: '/app/repos/$id'
+      preLoaderRoute: typeof AppAppReposIdRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/_app/app/private/$cwd': {
+      id: '/_app/app/private/$cwd'
+      path: '/app/private/$cwd'
+      fullPath: '/app/private/$cwd'
+      preLoaderRoute: typeof AppAppPrivateCwdRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/_app/app/logs/$id': {
+      id: '/_app/app/logs/$id'
+      path: '/app/logs/$id'
+      fullPath: '/app/logs/$id'
+      preLoaderRoute: typeof AppAppLogsIdRouteImport
       parentRoute: typeof AppRoute
     }
   }
 }
 
 interface AppRouteChildren {
-  AppAppRoute: typeof AppAppRoute
-  AppDeviceRoute: typeof AppDeviceRoute
-  AppPrivateCwdRoute: typeof AppPrivateCwdRoute
-  AppReposIdRoute: typeof AppReposIdRoute
+  AppAppDeviceRoute: typeof AppAppDeviceRoute
   AppSSessionIdRoute: typeof AppSSessionIdRoute
-  AppTranscriptsIdRoute: typeof AppTranscriptsIdRoute
+  AppAppIndexRoute: typeof AppAppIndexRoute
+  AppAppLogsIdRoute: typeof AppAppLogsIdRoute
+  AppAppPrivateCwdRoute: typeof AppAppPrivateCwdRoute
+  AppAppReposIdRoute: typeof AppAppReposIdRoute
 }
 
 const AppRouteChildren: AppRouteChildren = {
-  AppAppRoute: AppAppRoute,
-  AppDeviceRoute: AppDeviceRoute,
-  AppPrivateCwdRoute: AppPrivateCwdRoute,
-  AppReposIdRoute: AppReposIdRoute,
+  AppAppDeviceRoute: AppAppDeviceRoute,
   AppSSessionIdRoute: AppSSessionIdRoute,
-  AppTranscriptsIdRoute: AppTranscriptsIdRoute,
+  AppAppIndexRoute: AppAppIndexRoute,
+  AppAppLogsIdRoute: AppAppLogsIdRoute,
+  AppAppPrivateCwdRoute: AppAppPrivateCwdRoute,
+  AppAppReposIdRoute: AppAppReposIdRoute,
 }
 
 const AppRouteWithChildren = AppRoute._addFileChildren(AppRouteChildren)

--- a/packages/web/src/routes/_app/app/device.tsx
+++ b/packages/web/src/routes/_app/app/device.tsx
@@ -1,11 +1,11 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
-import { Button } from "../../components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../components/ui/card";
-import { InputOTP, InputOTPGroup, InputOTPSlot } from "../../components/ui/input-otp";
-import { authClient } from "../../lib/auth-client";
+import { Button } from "../../../components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../../components/ui/card";
+import { InputOTP, InputOTPGroup, InputOTPSlot } from "../../../components/ui/input-otp";
+import { authClient } from "../../../lib/auth-client";
 
-export const Route = createFileRoute("/_app/device")({
+export const Route = createFileRoute("/_app/app/device")({
   component: DeviceAuthorizationPage,
   validateSearch: (search: Record<string, unknown>) => {
     return {

--- a/packages/web/src/routes/_app/app/index.tsx
+++ b/packages/web/src/routes/_app/app/index.tsx
@@ -3,11 +3,11 @@ import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { ChevronDown, FileCode, Folder, MessageSquare, Search, Terminal, Wrench } from "lucide-react";
-import { ClaudeCodeIcon, CodexIcon, OpenCodeIcon } from "../../components/icons/source-icons";
+import { ClaudeCodeIcon, CodexIcon, OpenCodeIcon } from "../../../components/icons/source-icons";
 import { useMemo, useState } from "react";
-import { getAllTranscripts } from "../../lib/server-functions";
+import { getAllTranscripts } from "../../../lib/server-functions";
 
-export const Route = createFileRoute("/_app/app")({
+export const Route = createFileRoute("/_app/app/")({
   loader: async () => {
     try {
       const transcripts = await getAllTranscripts();

--- a/packages/web/src/routes/_app/app/logs.$id.tsx
+++ b/packages/web/src/routes/_app/app/logs.$id.tsx
@@ -21,12 +21,12 @@ import {
   Terminal,
   Zap,
 } from "lucide-react";
-import { ClaudeCodeIcon, CodexIcon, OpenCodeIcon } from "../../components/icons/source-icons";
+import { ClaudeCodeIcon, CodexIcon, OpenCodeIcon } from "../../../components/icons/source-icons";
 import { useEffect, useState } from "react";
-import { extractImageReferences, replaceImageReferencesForDisplay, type ImageReference } from "../../lib/message-utils";
-import { getTranscript } from "../../lib/server-functions";
+import { extractImageReferences, replaceImageReferencesForDisplay, type ImageReference } from "../../../lib/message-utils";
+import { getTranscript } from "../../../lib/server-functions";
 
-export const Route = createFileRoute("/_app/transcripts/$id")({
+export const Route = createFileRoute("/_app/app/logs/$id")({
   loader: ({ params }) => getTranscript({ data: params.id }),
   component: TranscriptDetailComponent,
 });

--- a/packages/web/src/routes/_app/app/private.$cwd.tsx
+++ b/packages/web/src/routes/_app/app/private.$cwd.tsx
@@ -4,19 +4,19 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { getTranscriptsByRepo } from "../../lib/server-functions";
+import { getTranscriptsByCwd } from "../../../lib/server-functions";
 
-type RepoTranscripts = Awaited<ReturnType<typeof getTranscriptsByRepo>>;
+type PrivateTranscripts = Awaited<ReturnType<typeof getTranscriptsByCwd>>;
 
-export const Route = createFileRoute("/_app/repos/$id")({
-  loader: ({ params }) => getTranscriptsByRepo({ data: params.id }),
-  component: RepoDetailComponent,
+export const Route = createFileRoute("/_app/app/private/$cwd")({
+  loader: ({ params }) => getTranscriptsByCwd({ data: params.cwd }),
+  component: PrivateDetailComponent,
 });
 
-function RepoDetailComponent() {
-  const transcripts = Route.useLoaderData() as RepoTranscripts;
-  const { id } = Route.useParams();
-  const formatSource = (source: RepoTranscripts[number]["source"]) => {
+function PrivateDetailComponent() {
+  const transcripts = Route.useLoaderData() as PrivateTranscripts;
+  const { cwd } = Route.useParams();
+  const formatSource = (source: PrivateTranscripts[number]["source"]) => {
     switch (source) {
       case "claude-code":
         return "Claude Code";
@@ -33,7 +33,7 @@ function RepoDetailComponent() {
         <Button variant="ghost" size="sm" asChild>
           <Link to="/app">← Back to Dashboard</Link>
         </Button>
-        <h2 className="text-2xl font-bold tracking-tight">Repository: {decodeURIComponent(id)}</h2>
+        <h2 className="text-2xl font-bold tracking-tight">Private Transcripts: {decodeURIComponent(cwd)}</h2>
       </div>
 
       <Card>
@@ -92,7 +92,7 @@ function RepoDetailComponent() {
                   </TableCell>
                   <TableCell className="text-right">
                     <Button variant="ghost" size="sm" asChild>
-                      <Link to="/transcripts/$id" params={{ id: transcript.id }}>
+                      <Link to="/app/logs/$id" params={{ id: transcript.id }}>
                         View
                       </Link>
                     </Button>

--- a/packages/web/src/routes/_app/app/repos.$id.tsx
+++ b/packages/web/src/routes/_app/app/repos.$id.tsx
@@ -4,19 +4,19 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { getTranscriptsByCwd } from "../../lib/server-functions";
+import { getTranscriptsByRepo } from "../../../lib/server-functions";
 
-type PrivateTranscripts = Awaited<ReturnType<typeof getTranscriptsByCwd>>;
+type RepoTranscripts = Awaited<ReturnType<typeof getTranscriptsByRepo>>;
 
-export const Route = createFileRoute("/_app/private/$cwd")({
-  loader: ({ params }) => getTranscriptsByCwd({ data: params.cwd }),
-  component: PrivateDetailComponent,
+export const Route = createFileRoute("/_app/app/repos/$id")({
+  loader: ({ params }) => getTranscriptsByRepo({ data: params.id }),
+  component: RepoDetailComponent,
 });
 
-function PrivateDetailComponent() {
-  const transcripts = Route.useLoaderData() as PrivateTranscripts;
-  const { cwd } = Route.useParams();
-  const formatSource = (source: PrivateTranscripts[number]["source"]) => {
+function RepoDetailComponent() {
+  const transcripts = Route.useLoaderData() as RepoTranscripts;
+  const { id } = Route.useParams();
+  const formatSource = (source: RepoTranscripts[number]["source"]) => {
     switch (source) {
       case "claude-code":
         return "Claude Code";
@@ -33,7 +33,7 @@ function PrivateDetailComponent() {
         <Button variant="ghost" size="sm" asChild>
           <Link to="/app">← Back to Dashboard</Link>
         </Button>
-        <h2 className="text-2xl font-bold tracking-tight">Private Transcripts: {decodeURIComponent(cwd)}</h2>
+        <h2 className="text-2xl font-bold tracking-tight">Repository: {decodeURIComponent(id)}</h2>
       </div>
 
       <Card>
@@ -92,7 +92,7 @@ function PrivateDetailComponent() {
                   </TableCell>
                   <TableCell className="text-right">
                     <Button variant="ghost" size="sm" asChild>
-                      <Link to="/transcripts/$id" params={{ id: transcript.id }}>
+                      <Link to="/app/logs/$id" params={{ id: transcript.id }}>
                         View
                       </Link>
                     </Button>

--- a/packages/web/src/routes/_app/s.$sessionId.tsx
+++ b/packages/web/src/routes/_app/s.$sessionId.tsx
@@ -6,7 +6,7 @@ export const Route = createFileRoute("/_app/s/$sessionId")({
     const transcript = await getTranscriptBySessionId({ data: params.sessionId });
 
     throw redirect({
-      to: "/transcripts/$id",
+      to: "/app/logs/$id",
       params: {
         id: transcript.id,
       },


### PR DESCRIPTION
### Motivation

- Preserve the short session URL so redirect links remain `https://agentlogs.ai/s/$sessionId` for compact commit messages.
- Ensure transcript detail pages continue to live under the authenticated UI at `/app/logs/$id` and redirects point there.
- Keep CLI-generated commit links using the unprefixed `/s` short path for backward compatibility.
- Reconcile the generated route tree and imports after moving authenticated UI files under the `/app` scope.

### Description

- Restored the short session route file `packages/web/src/routes/_app/s.$sessionId.tsx` which uses `createFileRoute("/_app/s/$sessionId")` and redirects to `/app/logs/$id`.
- Updated the generated route map in `packages/web/src/routeTree.gen.ts` to reference the `/s/$sessionId` short path and to reflect moved `app/*` route imports and IDs.
- Reverted CLI link generation in `packages/cli/src/commands/hook.ts` and its test to append `https://agentlogs.ai/s/${sessionId}` to commit messages.
- Kept transcript detail and repo/private routes under the new `/app/*` paths and updated OpenCode upload and README to build `/app/logs/$id` URLs.

### Testing

- Ran `bun run format`, which failed due to `concurrently` not being available (script exited with code 127).
- No other automated test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696587b69390833398adfcbce17b0b71)