### PR TITLE
feat(dashboard): add team dashboard

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -90,6 +90,7 @@
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-markdown": "^10.1.0",
+        "recharts": "2.15.4",
         "remark-gfm": "^4.0.1",
         "resend": "^6.8.0",
         "shadcn": "^3.7.0",
@@ -832,6 +833,24 @@
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
@@ -1054,9 +1073,33 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
 
     "decode-named-character-reference": ["decode-named-character-reference@1.2.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q=="],
 
@@ -1087,6 +1130,8 @@
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "diff": ["diff@8.0.2", "", {}, "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg=="],
+
+    "dom-helpers": ["dom-helpers@5.2.1", "", { "dependencies": { "@babel/runtime": "^7.8.7", "csstype": "^3.0.2" } }, "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA=="],
 
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
 
@@ -1154,6 +1199,8 @@
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
+    "eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
+
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
     "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
@@ -1171,6 +1218,8 @@
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-equals": ["fast-equals@5.4.0", "", {}, "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
@@ -1300,6 +1349,8 @@
 
     "input-otp": ["input-otp@1.4.2", "", { "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA=="],
 
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
+
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
@@ -1417,6 +1468,8 @@
     "log-symbols": ["log-symbols@6.0.0", "", { "dependencies": { "chalk": "^5.3.0", "is-unicode-supported": "^1.3.0" } }, "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw=="],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
+
+    "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
@@ -1706,6 +1759,8 @@
 
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
 
+    "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
+
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
@@ -1730,15 +1785,25 @@
 
     "react-dom": ["react-dom@19.2.3", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.3" } }, "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg=="],
 
+    "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
+
     "react-markdown": ["react-markdown@10.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="],
 
     "react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
+
+    "react-smooth": ["react-smooth@4.0.4", "", { "dependencies": { "fast-equals": "^5.0.1", "prop-types": "^15.8.1", "react-transition-group": "^4.4.5" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q=="],
+
+    "react-transition-group": ["react-transition-group@4.4.5", "", { "dependencies": { "@babel/runtime": "^7.5.5", "dom-helpers": "^5.0.1", "loose-envify": "^1.4.0", "prop-types": "^15.6.2" }, "peerDependencies": { "react": ">=16.6.0", "react-dom": ">=16.6.0" } }, "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g=="],
 
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
+
+    "recharts": ["recharts@2.15.4", "", { "dependencies": { "clsx": "^2.0.0", "eventemitter3": "^4.0.1", "lodash": "^4.17.21", "react-is": "^18.3.1", "react-smooth": "^4.0.4", "recharts-scale": "^0.4.4", "tiny-invariant": "^1.3.1", "victory-vendor": "^36.6.8" }, "peerDependencies": { "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw=="],
+
+    "recharts-scale": ["recharts-scale@0.4.5", "", { "dependencies": { "decimal.js-light": "^2.4.1" } }, "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w=="],
 
     "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
 
@@ -1994,6 +2059,8 @@
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
+    "victory-vendor": ["victory-vendor@36.9.2", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ=="],
+
     "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
     "vite-plugin-devtools-json": ["vite-plugin-devtools-json@1.0.0", "", { "dependencies": { "uuid": "^11.1.0" }, "peerDependencies": { "vite": "^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-MobvwqX76Vqt/O4AbnNMNWoXWGrKUqZbphCUle/J2KXH82yKQiunOeKnz/nqEPosPsoWWPP9FtNuPBSYpiiwkw=="],
@@ -2217,6 +2284,8 @@
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
+
+    "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
     "restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -43,6 +43,7 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-markdown": "^10.1.0",
+    "recharts": "2.15.4",
     "remark-gfm": "^4.0.1",
     "resend": "^6.8.0",
     "shadcn": "^3.7.0",

--- a/packages/web/src/db/queries.ts
+++ b/packages/web/src/db/queries.ts
@@ -1,6 +1,6 @@
 import { and, count, desc, eq, exists, isNull, like, lt, or, sql } from "drizzle-orm";
 import type { DrizzleDB } from ".";
-import { repos, teamInvites, teamMembers, teams, transcripts, user, type UserRole } from "./schema";
+import { commitTracking, repos, teamInvites, teamMembers, teams, transcripts, user, type UserRole } from "./schema";
 
 /**
  * Get all repos for a user with computed transcript count
@@ -755,4 +755,378 @@ export async function canAccessPublicBlob(db: DrizzleDB, blobSha256: string) {
     .first();
 
   return result !== null;
+}
+
+// Team Dashboard Queries
+// =============================================================================
+
+export interface TeamDashboardStats {
+  sessionCount: number;
+  linesAdded: number;
+  linesRemoved: number;
+  linesModified: number;
+}
+
+export interface TeamMemberStats {
+  userId: string;
+  name: string;
+  image: string | null;
+  transcriptCount: number;
+  linesAdded: number;
+  linesRemoved: number;
+  linesModified: number;
+  commitCount: number;
+}
+
+export interface TeamModelUsage {
+  model: string;
+  messageCount: number;
+}
+
+/**
+ * Get team member user IDs
+ */
+export async function getTeamMemberIds(db: DrizzleDB, teamId: string): Promise<string[]> {
+  const members = await db
+    .select({ userId: teamMembers.userId })
+    .from(teamMembers)
+    .where(eq(teamMembers.teamId, teamId));
+  return members.map((m) => m.userId);
+}
+
+/**
+ * Get aggregated team dashboard stats for a period
+ */
+export async function getTeamDashboardStats(
+  db: DrizzleDB,
+  teamId: string,
+  startDate: Date,
+  endDate: Date,
+): Promise<TeamDashboardStats> {
+  const memberIds = await getTeamMemberIds(db, teamId);
+  if (memberIds.length === 0) {
+    return { sessionCount: 0, linesAdded: 0, linesRemoved: 0, linesModified: 0 };
+  }
+
+  const startTimestamp = Math.floor(startDate.getTime() / 1000);
+  const endTimestamp = Math.floor(endDate.getTime() / 1000);
+
+  const result = await db
+    .select({
+      sessionCount: sql<number>`CAST(COUNT(*) AS INTEGER)`,
+      linesAdded: sql<number>`COALESCE(SUM(${transcripts.linesAdded}), 0)`,
+      linesRemoved: sql<number>`COALESCE(SUM(${transcripts.linesRemoved}), 0)`,
+      linesModified: sql<number>`COALESCE(SUM(${transcripts.linesModified}), 0)`,
+    })
+    .from(transcripts)
+    .where(
+      and(
+        sql`${transcripts.userId} IN ${memberIds}`,
+        sql`${transcripts.createdAt} >= ${startTimestamp}`,
+        sql`${transcripts.createdAt} <= ${endTimestamp}`,
+      ),
+    );
+
+  const stats = result[0];
+  return {
+    sessionCount: stats?.sessionCount ?? 0,
+    linesAdded: stats?.linesAdded ?? 0,
+    linesRemoved: stats?.linesRemoved ?? 0,
+    linesModified: stats?.linesModified ?? 0,
+  };
+}
+
+/**
+ * Get daily activity for team (for line chart)
+ */
+export async function getTeamDailyActivity(
+  db: DrizzleDB,
+  teamId: string,
+  days: number = 365,
+): Promise<{ date: string; count: number }[]> {
+  const memberIds = await getTeamMemberIds(db, teamId);
+  if (memberIds.length === 0) {
+    return [];
+  }
+
+  const startDate = new Date();
+  startDate.setDate(startDate.getDate() - days);
+  const startTimestamp = Math.floor(startDate.getTime() / 1000);
+
+  const results = await db
+    .select({
+      date: sql<string>`DATE(${transcripts.createdAt}, 'unixepoch')`.as("date"),
+      count: sql<number>`CAST(COUNT(*) AS INTEGER)`.as("count"),
+    })
+    .from(transcripts)
+    .where(and(sql`${transcripts.userId} IN ${memberIds}`, sql`${transcripts.createdAt} >= ${startTimestamp}`))
+    .groupBy(sql`DATE(${transcripts.createdAt}, 'unixepoch')`)
+    .orderBy(sql`DATE(${transcripts.createdAt}, 'unixepoch')`);
+
+  return results;
+}
+
+/**
+ * Get team members with their stats for a period
+ */
+export async function getTeamMembersWithStats(
+  db: DrizzleDB,
+  teamId: string,
+  startDate: Date,
+  endDate: Date,
+): Promise<TeamMemberStats[]> {
+  const startTimestamp = Math.floor(startDate.getTime() / 1000);
+  const endTimestamp = Math.floor(endDate.getTime() / 1000);
+
+  // Get team members with user info
+  const members = await db
+    .select({
+      userId: teamMembers.userId,
+      name: user.name,
+      image: user.image,
+    })
+    .from(teamMembers)
+    .innerJoin(user, eq(user.id, teamMembers.userId))
+    .where(eq(teamMembers.teamId, teamId));
+
+  if (members.length === 0) {
+    return [];
+  }
+
+  const memberIds = members.map((m) => m.userId);
+
+  // Get transcript stats per user
+  const transcriptStats = await db
+    .select({
+      userId: transcripts.userId,
+      transcriptCount: sql<number>`CAST(COUNT(*) AS INTEGER)`,
+      linesAdded: sql<number>`COALESCE(SUM(${transcripts.linesAdded}), 0)`,
+      linesRemoved: sql<number>`COALESCE(SUM(${transcripts.linesRemoved}), 0)`,
+      linesModified: sql<number>`COALESCE(SUM(${transcripts.linesModified}), 0)`,
+    })
+    .from(transcripts)
+    .where(
+      and(
+        sql`${transcripts.userId} IN ${memberIds}`,
+        sql`${transcripts.createdAt} >= ${startTimestamp}`,
+        sql`${transcripts.createdAt} <= ${endTimestamp}`,
+      ),
+    )
+    .groupBy(transcripts.userId);
+
+  // Get commit counts per user
+  const commitStats = await db
+    .select({
+      userId: commitTracking.userId,
+      commitCount: sql<number>`CAST(COUNT(*) AS INTEGER)`,
+    })
+    .from(commitTracking)
+    .where(
+      and(
+        sql`${commitTracking.userId} IN ${memberIds}`,
+        sql`${commitTracking.createdAt} >= ${startTimestamp}`,
+        sql`${commitTracking.createdAt} <= ${endTimestamp}`,
+      ),
+    )
+    .groupBy(commitTracking.userId);
+
+  // Combine data
+  const transcriptMap = new Map(transcriptStats.map((t) => [t.userId, t]));
+  const commitMap = new Map(commitStats.map((c) => [c.userId, c.commitCount]));
+
+  return members.map((m) => {
+    const ts = transcriptMap.get(m.userId);
+    return {
+      userId: m.userId,
+      name: m.name,
+      image: m.image,
+      transcriptCount: ts?.transcriptCount ?? 0,
+      linesAdded: ts?.linesAdded ?? 0,
+      linesRemoved: ts?.linesRemoved ?? 0,
+      linesModified: ts?.linesModified ?? 0,
+      commitCount: commitMap.get(m.userId) ?? 0,
+    };
+  });
+}
+
+/**
+ * Get model usage across team for a period
+ */
+export async function getTeamModelUsage(
+  db: DrizzleDB,
+  teamId: string,
+  startDate: Date,
+  endDate: Date,
+): Promise<TeamModelUsage[]> {
+  const memberIds = await getTeamMemberIds(db, teamId);
+  if (memberIds.length === 0) {
+    return [];
+  }
+
+  const startTimestamp = Math.floor(startDate.getTime() / 1000);
+  const endTimestamp = Math.floor(endDate.getTime() / 1000);
+
+  const results = await db
+    .select({
+      model: transcripts.model,
+      messageCount: sql<number>`COALESCE(SUM(${transcripts.userMessageCount}), 0)`,
+    })
+    .from(transcripts)
+    .where(
+      and(
+        sql`${transcripts.userId} IN ${memberIds}`,
+        sql`${transcripts.createdAt} >= ${startTimestamp}`,
+        sql`${transcripts.createdAt} <= ${endTimestamp}`,
+        sql`${transcripts.model} IS NOT NULL`,
+      ),
+    )
+    .groupBy(transcripts.model)
+    .orderBy(sql`SUM(${transcripts.userMessageCount}) DESC`);
+
+  return results.map((r) => ({
+    model: r.model || "unknown",
+    messageCount: r.messageCount,
+  }));
+}
+
+/**
+ * Get daily lines stats for team (for lines trend chart)
+ */
+export async function getTeamDailyLines(
+  db: DrizzleDB,
+  teamId: string,
+  days: number = 30,
+): Promise<{ date: string; added: number; removed: number; modified: number }[]> {
+  const memberIds = await getTeamMemberIds(db, teamId);
+  if (memberIds.length === 0) {
+    return [];
+  }
+
+  const startDate = new Date();
+  startDate.setDate(startDate.getDate() - days);
+  const startTimestamp = Math.floor(startDate.getTime() / 1000);
+
+  const results = await db
+    .select({
+      date: sql<string>`DATE(${transcripts.createdAt}, 'unixepoch')`.as("date"),
+      added: sql<number>`COALESCE(SUM(${transcripts.linesAdded}), 0)`.as("added"),
+      removed: sql<number>`COALESCE(SUM(${transcripts.linesRemoved}), 0)`.as("removed"),
+      modified: sql<number>`COALESCE(SUM(${transcripts.linesModified}), 0)`.as("modified"),
+    })
+    .from(transcripts)
+    .where(and(sql`${transcripts.userId} IN ${memberIds}`, sql`${transcripts.createdAt} >= ${startTimestamp}`))
+    .groupBy(sql`DATE(${transcripts.createdAt}, 'unixepoch')`)
+    .orderBy(sql`DATE(${transcripts.createdAt}, 'unixepoch')`);
+
+  return results;
+}
+
+/**
+ * Get daily agent (source) usage for team - for trend chart
+ */
+export async function getTeamDailyAgentUsage(
+  db: DrizzleDB,
+  teamId: string,
+  days: number = 30,
+): Promise<{ date: string; agent: string; count: number }[]> {
+  const memberIds = await getTeamMemberIds(db, teamId);
+  if (memberIds.length === 0) {
+    return [];
+  }
+
+  const startDate = new Date();
+  startDate.setDate(startDate.getDate() - days);
+  const startTimestamp = Math.floor(startDate.getTime() / 1000);
+
+  const results = await db
+    .select({
+      date: sql<string>`DATE(${transcripts.createdAt}, 'unixepoch')`.as("date"),
+      agent: transcripts.source,
+      count: sql<number>`CAST(COUNT(*) AS INTEGER)`.as("count"),
+    })
+    .from(transcripts)
+    .where(and(sql`${transcripts.userId} IN ${memberIds}`, sql`${transcripts.createdAt} >= ${startTimestamp}`))
+    .groupBy(sql`DATE(${transcripts.createdAt}, 'unixepoch')`, transcripts.source)
+    .orderBy(sql`DATE(${transcripts.createdAt}, 'unixepoch')`);
+
+  return results.map((r) => ({
+    date: r.date,
+    agent: r.agent || "unknown",
+    count: r.count,
+  }));
+}
+
+/**
+ * Get per-member daily activity for team - for sparklines
+ */
+export async function getTeamMembersDailyActivity(
+  db: DrizzleDB,
+  teamId: string,
+  days: number = 7,
+): Promise<{ userId: string; date: string; count: number }[]> {
+  const memberIds = await getTeamMemberIds(db, teamId);
+  if (memberIds.length === 0) {
+    return [];
+  }
+
+  const startDate = new Date();
+  startDate.setDate(startDate.getDate() - days);
+  const startTimestamp = Math.floor(startDate.getTime() / 1000);
+
+  const results = await db
+    .select({
+      userId: transcripts.userId,
+      date: sql<string>`DATE(${transcripts.createdAt}, 'unixepoch')`.as("date"),
+      count: sql<number>`CAST(COUNT(*) AS INTEGER)`.as("count"),
+    })
+    .from(transcripts)
+    .where(and(sql`${transcripts.userId} IN ${memberIds}`, sql`${transcripts.createdAt} >= ${startTimestamp}`))
+    .groupBy(transcripts.userId, sql`DATE(${transcripts.createdAt}, 'unixepoch')`)
+    .orderBy(sql`DATE(${transcripts.createdAt}, 'unixepoch')`);
+
+  return results.map((r) => ({
+    userId: r.userId,
+    date: r.date,
+    count: r.count,
+  }));
+}
+
+/**
+ * Get per-member agent usage for team
+ */
+export async function getTeamMembersAgentUsage(
+  db: DrizzleDB,
+  teamId: string,
+  startDate: Date,
+  endDate: Date,
+): Promise<{ userId: string; agent: string; count: number }[]> {
+  const memberIds = await getTeamMemberIds(db, teamId);
+  if (memberIds.length === 0) {
+    return [];
+  }
+
+  const startTimestamp = Math.floor(startDate.getTime() / 1000);
+  const endTimestamp = Math.floor(endDate.getTime() / 1000);
+
+  const results = await db
+    .select({
+      userId: transcripts.userId,
+      agent: transcripts.source,
+      count: sql<number>`CAST(COUNT(*) AS INTEGER)`.as("count"),
+    })
+    .from(transcripts)
+    .where(
+      and(
+        sql`${transcripts.userId} IN ${memberIds}`,
+        sql`${transcripts.createdAt} >= ${startTimestamp}`,
+        sql`${transcripts.createdAt} <= ${endTimestamp}`,
+      ),
+    )
+    .groupBy(transcripts.userId, transcripts.source);
+
+  return results.map((r) => ({
+    userId: r.userId,
+    agent: r.agent || "unknown",
+    count: r.count,
+  }));
 }

--- a/packages/web/src/lib/formatters.ts
+++ b/packages/web/src/lib/formatters.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared formatting utilities
+ */
+
+/**
+ * Format a number with K suffix for thousands
+ * 1000 → "1.0k", 500 → "500"
+ */
+export function formatCompactNumber(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
+  return n.toString();
+}
+
+/**
+ * Parse and format model display names
+ * - claude-opus-4-5-20251101 → Claude Opus 4.5
+ * - claude-sonnet-4-20250514 → Claude Sonnet 4
+ * - gpt-4-... → GPT-4
+ */
+export function getModelDisplayName(model: string | null): string {
+  if (!model) return "Unknown";
+
+  // Parse Claude model strings
+  const match = model.match(/^claude-(?:(\d+)-(\d+)-)?(opus|sonnet|haiku)(?:-(\d+)(?:-(\d+))?)?-\d{8}$/);
+  if (match) {
+    const [, oldMajor, oldMinor, family, newMajor, newMinor] = match;
+    const major = newMajor ?? oldMajor;
+    const minor = newMinor ?? oldMinor;
+    const version = minor ? `${major}.${minor}` : major;
+    const familyName = family.charAt(0).toUpperCase() + family.slice(1);
+    return `Claude ${familyName} ${version}`;
+  }
+
+  // Handle GPT models
+  if (model.includes("gpt-4")) return "GPT-4";
+  if (model.includes("gpt-3.5")) return "GPT-3.5";
+
+  return model;
+}
+
+/**
+ * Format agent source name for display
+ */
+export function getAgentDisplayName(agent: string): string {
+  switch (agent.toLowerCase()) {
+    case "claude-code":
+      return "Claude Code";
+    case "codex":
+      return "Codex CLI";
+    case "opencode":
+      return "OpenCode";
+    default:
+      return agent;
+  }
+}

--- a/packages/web/src/lib/server-functions.ts
+++ b/packages/web/src/lib/server-functions.ts
@@ -877,3 +877,215 @@ export const updateVisibility = createServerFn({ method: "POST" })
     logger.info("Transcript visibility updated", { transcriptId, visibility, sharedWithTeamId, userId });
     return { success: true, visibility, sharedWithTeamId };
   });
+
+// =============================================================================
+// Dashboard Server Functions
+// =============================================================================
+
+type DashboardPeriod = "today" | "week" | "month";
+
+function getPeriodRange(period: DashboardPeriod): { start: Date; end: Date } {
+  const now = new Date();
+  const end = now;
+  let start: Date;
+
+  switch (period) {
+    case "today":
+      start = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+      break;
+    case "week":
+      start = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+      break;
+    case "month":
+      start = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+      break;
+  }
+
+  return { start, end };
+}
+
+// =============================================================================
+// Team Dashboard Server Functions
+// =============================================================================
+
+/**
+ * Get team dashboard stats
+ */
+export const getTeamDashboardStats = createServerFn({ method: "GET" })
+  .inputValidator((input: { teamId: string; period: DashboardPeriod }) => input)
+  .handler(async ({ data: { teamId, period } }) => {
+    const db = createDrizzle(env.DB);
+    const userId = await getAuthenticatedUserId();
+
+    // Verify user is team member
+    const isMember = await queries.isTeamMember(db, teamId, userId);
+    if (!isMember) {
+      throw new Error("Not a member of this team");
+    }
+
+    const { start, end } = getPeriodRange(period);
+    return queries.getTeamDashboardStats(db, teamId, start, end);
+  });
+
+/**
+ * Get team daily activity for line chart
+ */
+export const getTeamDailyActivity = createServerFn({ method: "GET" })
+  .inputValidator((input: { teamId: string; days: number }) => input)
+  .handler(async ({ data: { teamId, days } }) => {
+    const db = createDrizzle(env.DB);
+    const userId = await getAuthenticatedUserId();
+
+    // Verify user is team member
+    const isMember = await queries.isTeamMember(db, teamId, userId);
+    if (!isMember) {
+      throw new Error("Not a member of this team");
+    }
+
+    const results = await queries.getTeamDailyActivity(db, teamId, days);
+
+    // Fill in missing days
+    const counts = new Map(results.map((r) => [r.date, r.count]));
+    const filledData: Array<{ date: string; count: number }> = [];
+    const today = new Date();
+
+    for (let i = days - 1; i >= 0; i--) {
+      const date = new Date(today);
+      date.setDate(date.getDate() - i);
+      const key = date.toISOString().split("T")[0];
+      filledData.push({ date: key, count: counts.get(key) ?? 0 });
+    }
+
+    return filledData;
+  });
+
+/**
+ * Get team members with their stats
+ */
+export const getTeamMembersWithStats = createServerFn({ method: "GET" })
+  .inputValidator((input: { teamId: string; period: DashboardPeriod }) => input)
+  .handler(async ({ data: { teamId, period } }) => {
+    const db = createDrizzle(env.DB);
+    const userId = await getAuthenticatedUserId();
+
+    // Verify user is team member
+    const isMember = await queries.isTeamMember(db, teamId, userId);
+    if (!isMember) {
+      throw new Error("Not a member of this team");
+    }
+
+    const { start, end } = getPeriodRange(period);
+    return queries.getTeamMembersWithStats(db, teamId, start, end);
+  });
+
+/**
+ * Get team model usage
+ */
+export const getTeamModelUsage = createServerFn({ method: "GET" })
+  .inputValidator((input: { teamId: string; period: DashboardPeriod }) => input)
+  .handler(async ({ data: { teamId, period } }) => {
+    const db = createDrizzle(env.DB);
+    const userId = await getAuthenticatedUserId();
+
+    // Verify user is team member
+    const isMember = await queries.isTeamMember(db, teamId, userId);
+    if (!isMember) {
+      throw new Error("Not a member of this team");
+    }
+
+    const { start, end } = getPeriodRange(period);
+    return queries.getTeamModelUsage(db, teamId, start, end);
+  });
+
+/**
+ * Get team daily lines stats for lines trend chart
+ */
+export const getTeamDailyLines = createServerFn({ method: "GET" })
+  .inputValidator((input: { teamId: string; days: number }) => input)
+  .handler(async ({ data: { teamId, days } }) => {
+    const db = createDrizzle(env.DB);
+    const userId = await getAuthenticatedUserId();
+
+    // Verify user is team member
+    const isMember = await queries.isTeamMember(db, teamId, userId);
+    if (!isMember) {
+      throw new Error("Not a member of this team");
+    }
+
+    const results = await queries.getTeamDailyLines(db, teamId, days);
+
+    // Fill in missing days with zeros
+    const dataMap = new Map(results.map((r) => [r.date, r]));
+    const filledData: Array<{ date: string; added: number; removed: number; modified: number }> = [];
+    const today = new Date();
+
+    for (let i = days - 1; i >= 0; i--) {
+      const date = new Date(today);
+      date.setDate(date.getDate() - i);
+      const key = date.toISOString().split("T")[0];
+      const existing = dataMap.get(key);
+      filledData.push({
+        date: key,
+        added: existing?.added ?? 0,
+        removed: existing?.removed ?? 0,
+        modified: existing?.modified ?? 0,
+      });
+    }
+
+    return filledData;
+  });
+
+/**
+ * Get team daily agent usage for trend chart
+ */
+export const getTeamDailyAgentUsage = createServerFn({ method: "GET" })
+  .inputValidator((input: { teamId: string; days: number }) => input)
+  .handler(async ({ data: { teamId, days } }) => {
+    const db = createDrizzle(env.DB);
+    const userId = await getAuthenticatedUserId();
+
+    // Verify user is team member
+    const isMember = await queries.isTeamMember(db, teamId, userId);
+    if (!isMember) {
+      throw new Error("Not a member of this team");
+    }
+
+    return queries.getTeamDailyAgentUsage(db, teamId, days);
+  });
+
+/**
+ * Get team members daily activity for sparklines
+ */
+export const getTeamMembersDailyActivity = createServerFn({ method: "GET" })
+  .inputValidator((input: { teamId: string; days: number }) => input)
+  .handler(async ({ data: { teamId, days } }) => {
+    const db = createDrizzle(env.DB);
+    const userId = await getAuthenticatedUserId();
+
+    // Verify user is team member
+    const isMember = await queries.isTeamMember(db, teamId, userId);
+    if (!isMember) {
+      throw new Error("Not a member of this team");
+    }
+
+    return queries.getTeamMembersDailyActivity(db, teamId, days);
+  });
+
+/**
+ * Get team members agent usage
+ */
+export const getTeamMembersAgentUsage = createServerFn({ method: "GET" })
+  .inputValidator((input: { teamId: string; period: DashboardPeriod }) => input)
+  .handler(async ({ data: { teamId, period } }) => {
+    const db = createDrizzle(env.DB);
+    const userId = await getAuthenticatedUserId();
+
+    // Verify user is team member
+    const isMember = await queries.isTeamMember(db, teamId, userId);
+    if (!isMember) {
+      throw new Error("Not a member of this team");
+    }
+
+    const { start, end } = getPeriodRange(period);
+    return queries.getTeamMembersAgentUsage(db, teamId, start, end);
+  });

--- a/packages/web/src/routeTree.gen.ts
+++ b/packages/web/src/routeTree.gen.ts
@@ -23,10 +23,11 @@ import { Route as ApiBlobsSha256RouteImport } from './routes/api/blobs.$sha256'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth.$'
 import { Route as AppSSessionIdRouteImport } from './routes/_app/s.$sessionId'
 import { Route as AppJoinCodeRouteImport } from './routes/_app/join.$code'
-import { Route as AppAppTeamRouteImport } from './routes/_app/app/team'
 import { Route as AppAppDeviceRouteImport } from './routes/_app/app/device'
 import { Route as AppAppAdminRouteImport } from './routes/_app/app/admin'
+import { Route as AppAppTeamIndexRouteImport } from './routes/_app/app/team/index'
 import { Route as ApiAdminTranscriptUnifiedIdRouteImport } from './routes/api/admin/transcript-unified.$id'
+import { Route as AppAppTeamDashboardRouteImport } from './routes/_app/app/team/dashboard'
 import { Route as AppAppPrivateCwdRouteImport } from './routes/_app/app/private.$cwd'
 import { Route as AppAppLogsIdRouteImport } from './routes/_app/app/logs.$id'
 
@@ -99,11 +100,6 @@ const AppJoinCodeRoute = AppJoinCodeRouteImport.update({
   path: '/join/$code',
   getParentRoute: () => AppRoute,
 } as any)
-const AppAppTeamRoute = AppAppTeamRouteImport.update({
-  id: '/app/team',
-  path: '/app/team',
-  getParentRoute: () => AppRoute,
-} as any)
 const AppAppDeviceRoute = AppAppDeviceRouteImport.update({
   id: '/app/device',
   path: '/app/device',
@@ -114,12 +110,22 @@ const AppAppAdminRoute = AppAppAdminRouteImport.update({
   path: '/app/admin',
   getParentRoute: () => AppRoute,
 } as any)
+const AppAppTeamIndexRoute = AppAppTeamIndexRouteImport.update({
+  id: '/app/team/',
+  path: '/app/team/',
+  getParentRoute: () => AppRoute,
+} as any)
 const ApiAdminTranscriptUnifiedIdRoute =
   ApiAdminTranscriptUnifiedIdRouteImport.update({
     id: '/api/admin/transcript-unified/$id',
     path: '/api/admin/transcript-unified/$id',
     getParentRoute: () => rootRouteImport,
   } as any)
+const AppAppTeamDashboardRoute = AppAppTeamDashboardRouteImport.update({
+  id: '/app/team/dashboard',
+  path: '/app/team/dashboard',
+  getParentRoute: () => AppRoute,
+} as any)
 const AppAppPrivateCwdRoute = AppAppPrivateCwdRouteImport.update({
   id: '/app/private/$cwd',
   path: '/app/private/$cwd',
@@ -141,7 +147,6 @@ export interface FileRoutesByFullPath {
   '/auth/$': typeof AuthSplatRoute
   '/app/admin': typeof AppAppAdminRoute
   '/app/device': typeof AppAppDeviceRoute
-  '/app/team': typeof AppAppTeamRoute
   '/join/$code': typeof AppJoinCodeRoute
   '/s/$sessionId': typeof AppSSessionIdRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
@@ -150,7 +155,9 @@ export interface FileRoutesByFullPath {
   '/app/': typeof AppAppIndexRoute
   '/app/logs/$id': typeof AppAppLogsIdRoute
   '/app/private/$cwd': typeof AppAppPrivateCwdRoute
+  '/app/team/dashboard': typeof AppAppTeamDashboardRoute
   '/api/admin/transcript-unified/$id': typeof ApiAdminTranscriptUnifiedIdRoute
+  '/app/team/': typeof AppAppTeamIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -162,7 +169,6 @@ export interface FileRoutesByTo {
   '/auth/$': typeof AuthSplatRoute
   '/app/admin': typeof AppAppAdminRoute
   '/app/device': typeof AppAppDeviceRoute
-  '/app/team': typeof AppAppTeamRoute
   '/join/$code': typeof AppJoinCodeRoute
   '/s/$sessionId': typeof AppSSessionIdRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
@@ -171,7 +177,9 @@ export interface FileRoutesByTo {
   '/app': typeof AppAppIndexRoute
   '/app/logs/$id': typeof AppAppLogsIdRoute
   '/app/private/$cwd': typeof AppAppPrivateCwdRoute
+  '/app/team/dashboard': typeof AppAppTeamDashboardRoute
   '/api/admin/transcript-unified/$id': typeof ApiAdminTranscriptUnifiedIdRoute
+  '/app/team': typeof AppAppTeamIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -185,7 +193,6 @@ export interface FileRoutesById {
   '/auth/$': typeof AuthSplatRoute
   '/_app/app/admin': typeof AppAppAdminRoute
   '/_app/app/device': typeof AppAppDeviceRoute
-  '/_app/app/team': typeof AppAppTeamRoute
   '/_app/join/$code': typeof AppJoinCodeRoute
   '/_app/s/$sessionId': typeof AppSSessionIdRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
@@ -194,7 +201,9 @@ export interface FileRoutesById {
   '/_app/app/': typeof AppAppIndexRoute
   '/_app/app/logs/$id': typeof AppAppLogsIdRoute
   '/_app/app/private/$cwd': typeof AppAppPrivateCwdRoute
+  '/_app/app/team/dashboard': typeof AppAppTeamDashboardRoute
   '/api/admin/transcript-unified/$id': typeof ApiAdminTranscriptUnifiedIdRoute
+  '/_app/app/team/': typeof AppAppTeamIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -208,7 +217,6 @@ export interface FileRouteTypes {
     | '/auth/$'
     | '/app/admin'
     | '/app/device'
-    | '/app/team'
     | '/join/$code'
     | '/s/$sessionId'
     | '/api/auth/$'
@@ -217,7 +225,9 @@ export interface FileRouteTypes {
     | '/app/'
     | '/app/logs/$id'
     | '/app/private/$cwd'
+    | '/app/team/dashboard'
     | '/api/admin/transcript-unified/$id'
+    | '/app/team/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -229,7 +239,6 @@ export interface FileRouteTypes {
     | '/auth/$'
     | '/app/admin'
     | '/app/device'
-    | '/app/team'
     | '/join/$code'
     | '/s/$sessionId'
     | '/api/auth/$'
@@ -238,7 +247,9 @@ export interface FileRouteTypes {
     | '/app'
     | '/app/logs/$id'
     | '/app/private/$cwd'
+    | '/app/team/dashboard'
     | '/api/admin/transcript-unified/$id'
+    | '/app/team'
   id:
     | '__root__'
     | '/'
@@ -251,7 +262,6 @@ export interface FileRouteTypes {
     | '/auth/$'
     | '/_app/app/admin'
     | '/_app/app/device'
-    | '/_app/app/team'
     | '/_app/join/$code'
     | '/_app/s/$sessionId'
     | '/api/auth/$'
@@ -260,7 +270,9 @@ export interface FileRouteTypes {
     | '/_app/app/'
     | '/_app/app/logs/$id'
     | '/_app/app/private/$cwd'
+    | '/_app/app/team/dashboard'
     | '/api/admin/transcript-unified/$id'
+    | '/_app/app/team/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -377,13 +389,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppJoinCodeRouteImport
       parentRoute: typeof AppRoute
     }
-    '/_app/app/team': {
-      id: '/_app/app/team'
-      path: '/app/team'
-      fullPath: '/app/team'
-      preLoaderRoute: typeof AppAppTeamRouteImport
-      parentRoute: typeof AppRoute
-    }
     '/_app/app/device': {
       id: '/_app/app/device'
       path: '/app/device'
@@ -398,12 +403,26 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppAppAdminRouteImport
       parentRoute: typeof AppRoute
     }
+    '/_app/app/team/': {
+      id: '/_app/app/team/'
+      path: '/app/team'
+      fullPath: '/app/team/'
+      preLoaderRoute: typeof AppAppTeamIndexRouteImport
+      parentRoute: typeof AppRoute
+    }
     '/api/admin/transcript-unified/$id': {
       id: '/api/admin/transcript-unified/$id'
       path: '/api/admin/transcript-unified/$id'
       fullPath: '/api/admin/transcript-unified/$id'
       preLoaderRoute: typeof ApiAdminTranscriptUnifiedIdRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/_app/app/team/dashboard': {
+      id: '/_app/app/team/dashboard'
+      path: '/app/team/dashboard'
+      fullPath: '/app/team/dashboard'
+      preLoaderRoute: typeof AppAppTeamDashboardRouteImport
+      parentRoute: typeof AppRoute
     }
     '/_app/app/private/$cwd': {
       id: '/_app/app/private/$cwd'
@@ -425,23 +444,25 @@ declare module '@tanstack/react-router' {
 interface AppRouteChildren {
   AppAppAdminRoute: typeof AppAppAdminRoute
   AppAppDeviceRoute: typeof AppAppDeviceRoute
-  AppAppTeamRoute: typeof AppAppTeamRoute
   AppJoinCodeRoute: typeof AppJoinCodeRoute
   AppSSessionIdRoute: typeof AppSSessionIdRoute
   AppAppIndexRoute: typeof AppAppIndexRoute
   AppAppLogsIdRoute: typeof AppAppLogsIdRoute
   AppAppPrivateCwdRoute: typeof AppAppPrivateCwdRoute
+  AppAppTeamDashboardRoute: typeof AppAppTeamDashboardRoute
+  AppAppTeamIndexRoute: typeof AppAppTeamIndexRoute
 }
 
 const AppRouteChildren: AppRouteChildren = {
   AppAppAdminRoute: AppAppAdminRoute,
   AppAppDeviceRoute: AppAppDeviceRoute,
-  AppAppTeamRoute: AppAppTeamRoute,
   AppJoinCodeRoute: AppJoinCodeRoute,
   AppSSessionIdRoute: AppSSessionIdRoute,
   AppAppIndexRoute: AppAppIndexRoute,
   AppAppLogsIdRoute: AppAppLogsIdRoute,
   AppAppPrivateCwdRoute: AppAppPrivateCwdRoute,
+  AppAppTeamDashboardRoute: AppAppTeamDashboardRoute,
+  AppAppTeamIndexRoute: AppAppTeamIndexRoute,
 }
 
 const AppRouteWithChildren = AppRoute._addFileChildren(AppRouteChildren)

--- a/packages/web/src/routes/_app.tsx
+++ b/packages/web/src/routes/_app.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useDebugMode } from "@/hooks/use-debug-mode";
 import { createFileRoute, Link, Outlet, redirect, useRouter } from "@tanstack/react-router";
-import { ChevronDownIcon, LogOutIcon, LogsIcon, ShieldIcon, UsersIcon } from "lucide-react";
+import { BarChart3Icon, ChevronDownIcon, LogOutIcon, LogsIcon, ShieldIcon, UsersIcon } from "lucide-react";
 import { DiscordIcon, Logo } from "@/components/icons/source-icons";
 import { authClient } from "../lib/auth-client";
 import { getSession } from "../lib/server-functions";
@@ -85,6 +85,13 @@ function AppLayout() {
               >
                 <LogsIcon className="size-4" />
                 Logs
+              </Link>
+              <Link
+                to="/app/team/dashboard"
+                className="flex items-center gap-2 text-sm text-white/50 transition-colors hover:text-white data-[status=active]:text-white"
+              >
+                <BarChart3Icon className="size-4" />
+                Dashboard
               </Link>
               <Link
                 to="/app/team"

--- a/packages/web/src/routes/_app/app/logs.$id.tsx
+++ b/packages/web/src/routes/_app/app/logs.$id.tsx
@@ -1,6 +1,7 @@
 import { Badge } from "@/components/ui/badge";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Select, SelectContent, SelectItem, SelectTrigger } from "@/components/ui/select";
+import { getModelDisplayName } from "@/lib/formatters";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { createFileRoute, useRouter } from "@tanstack/react-router";
 import type { UnifiedTranscriptMessage } from "@agentlogs/shared/claudecode";
@@ -106,25 +107,6 @@ function getSourceIcon(source: string, className?: string) {
     default:
       return <Terminal className={className} />;
   }
-}
-
-function getModelDisplayName(model: string | null): string {
-  if (!model) return "Unknown";
-
-  // Parse model strings like:
-  // - claude-opus-4-5-20251101 → Claude Opus 4.5
-  // - claude-sonnet-4-20250514 → Claude Sonnet 4
-  // - claude-3-5-haiku-20241022 → Claude Haiku 3.5
-  const match = model.match(/^claude-(?:(\d+)-(\d+)-)?(opus|sonnet|haiku)(?:-(\d+)(?:-(\d+))?)?-\d{8}$/);
-  if (!match) return model;
-
-  const [, oldMajor, oldMinor, family, newMajor, newMinor] = match;
-  const major = newMajor ?? oldMajor;
-  const minor = newMinor ?? oldMinor;
-  const version = minor ? `${major}.${minor}` : major;
-  const familyName = family.charAt(0).toUpperCase() + family.slice(1);
-
-  return `Claude ${familyName} ${version}`;
 }
 
 function formatRepoName(repo: string): { label: string; isGitHub: boolean } {

--- a/packages/web/src/routes/_app/app/private.$cwd.tsx
+++ b/packages/web/src/routes/_app/app/private.$cwd.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { getTranscriptsByCwd } from "../../../lib/server-functions";
+import { getAgentDisplayName } from "@/lib/formatters";
 
 type PrivateTranscripts = Awaited<ReturnType<typeof getTranscriptsByCwd>>;
 
@@ -16,16 +17,6 @@ export const Route = createFileRoute("/_app/app/private/$cwd")({
 function PrivateDetailComponent() {
   const transcripts = Route.useLoaderData() as PrivateTranscripts;
   const { cwd } = Route.useParams();
-  const formatSource = (source: PrivateTranscripts[number]["source"]) => {
-    switch (source) {
-      case "claude-code":
-        return "Claude Code";
-      case "codex":
-        return "Codex";
-      default:
-        return "Unknown";
-    }
-  };
 
   return (
     <div className="space-y-6">
@@ -77,7 +68,7 @@ function PrivateDetailComponent() {
                     <code className="font-mono text-sm">{transcript.transcriptId?.slice(0, 8) || "N/A"}...</code>
                   </TableCell>
                   <TableCell>
-                    <Badge variant="outline">{formatSource(transcript.source)}</Badge>
+                    <Badge variant="outline">{getAgentDisplayName(transcript.source)}</Badge>
                   </TableCell>
                   <TableCell className="max-w-md truncate text-muted-foreground">
                     {transcript.preview || "No preview"}

--- a/packages/web/src/routes/_app/app/team/dashboard.tsx
+++ b/packages/web/src/routes/_app/app/team/dashboard.tsx
@@ -1,0 +1,781 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { useState } from "react";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  getTeam,
+  getTeamDashboardStats,
+  getTeamDailyActivity,
+  getTeamMembersWithStats,
+  getTeamModelUsage,
+  getTeamDailyLines,
+  getTeamDailyAgentUsage,
+  getTeamMembersDailyActivity,
+  getTeamMembersAgentUsage,
+} from "@/lib/server-functions";
+import { formatCompactNumber, getModelDisplayName, getAgentDisplayName } from "@/lib/formatters";
+
+type Period = "today" | "week" | "month";
+
+export const Route = createFileRoute("/_app/app/team/dashboard")({
+  loader: async () => {
+    const team = await getTeam();
+
+    if (!team) {
+      // No team - redirect to team page to create/join one
+      throw redirect({ to: "/app/team" });
+    }
+
+    const [
+      stats,
+      dailyActivity,
+      members,
+      modelUsage,
+      dailyLines,
+      dailyAgentUsage,
+      membersDailyActivity,
+      membersAgentUsage,
+    ] = await Promise.all([
+      getTeamDashboardStats({ data: { teamId: team.id, period: "week" } }),
+      getTeamDailyActivity({ data: { teamId: team.id, days: 365 } }),
+      getTeamMembersWithStats({ data: { teamId: team.id, period: "week" } }),
+      getTeamModelUsage({ data: { teamId: team.id, period: "week" } }),
+      getTeamDailyLines({ data: { teamId: team.id, days: 30 } }),
+      getTeamDailyAgentUsage({ data: { teamId: team.id, days: 30 } }),
+      getTeamMembersDailyActivity({ data: { teamId: team.id, days: 7 } }),
+      getTeamMembersAgentUsage({ data: { teamId: team.id, period: "week" } }),
+    ]);
+
+    return {
+      team,
+      stats,
+      dailyActivity,
+      members,
+      modelUsage,
+      dailyLines,
+      dailyAgentUsage,
+      membersDailyActivity,
+      membersAgentUsage,
+    };
+  },
+  component: TeamDashboardPage,
+});
+
+function TeamDashboardPage() {
+  const initialData = Route.useLoaderData();
+  const [period, setPeriod] = useState<Period>("week");
+  const [stats, setStats] = useState(initialData.stats);
+  const [members, setMembers] = useState(initialData.members);
+  const [modelUsage, setModelUsage] = useState(initialData.modelUsage);
+  const [dailyAgentUsage, setDailyAgentUsage] = useState(initialData.dailyAgentUsage);
+  const [membersDailyActivity, setMembersDailyActivity] = useState(initialData.membersDailyActivity);
+  const [membersAgentUsage, setMembersAgentUsage] = useState(initialData.membersAgentUsage);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const getPeriodDays = (p: Period) => {
+    switch (p) {
+      case "today":
+        return 1;
+      case "week":
+        return 7;
+      case "month":
+        return 30;
+    }
+  };
+
+  const handlePeriodChange = async (newPeriod: Period) => {
+    setPeriod(newPeriod);
+    setIsLoading(true);
+    try {
+      const days = getPeriodDays(newPeriod);
+      const [newStats, newMembers, newModelUsage, newDailyAgentUsage, newMembersDailyActivity, newMembersAgentUsage] =
+        await Promise.all([
+          getTeamDashboardStats({ data: { teamId: initialData.team.id, period: newPeriod } }),
+          getTeamMembersWithStats({ data: { teamId: initialData.team.id, period: newPeriod } }),
+          getTeamModelUsage({ data: { teamId: initialData.team.id, period: newPeriod } }),
+          getTeamDailyAgentUsage({ data: { teamId: initialData.team.id, days } }),
+          getTeamMembersDailyActivity({ data: { teamId: initialData.team.id, days } }),
+          getTeamMembersAgentUsage({ data: { teamId: initialData.team.id, period: newPeriod } }),
+        ]);
+      setStats(newStats);
+      setMembers(newMembers);
+      setModelUsage(newModelUsage);
+      setDailyAgentUsage(newDailyAgentUsage);
+      setMembersDailyActivity(newMembersDailyActivity);
+      setMembersAgentUsage(newMembersAgentUsage);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const team = initialData.team;
+
+  return (
+    <div className="container max-w-4xl space-y-4 py-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="font-serif text-xl">{team.name}</h1>
+          <p className="text-sm text-muted-foreground">
+            {team.members.length} member{team.members.length !== 1 ? "s" : ""}
+          </p>
+        </div>
+        <Select value={period} onValueChange={(v) => handlePeriodChange(v as Period)}>
+          <SelectTrigger className="h-8 w-28 text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="today">Today</SelectItem>
+            <SelectItem value="week">This Week</SelectItem>
+            <SelectItem value="month">This Month</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Summary Stats (no cost) */}
+      <div className={`rounded-lg border bg-card p-4 ${isLoading ? "opacity-50" : ""}`}>
+        <TeamSummary
+          period={period}
+          sessionCount={stats.sessionCount}
+          linesAdded={stats.linesAdded}
+          linesRemoved={stats.linesRemoved}
+          linesModified={stats.linesModified}
+        />
+      </div>
+
+      {/* Activity Line Chart */}
+      <div className="rounded-lg border bg-card p-4">
+        <ActivityLineChart data={initialData.dailyActivity} />
+      </div>
+
+      {/* Agent Sparklines & Prompts by Model (side by side) */}
+      <div className={`grid grid-cols-2 gap-4 ${isLoading ? "opacity-50" : ""}`}>
+        <div className="rounded-lg border bg-card p-4">
+          <AgentSparklines data={dailyAgentUsage} period={period} />
+        </div>
+        <div className="rounded-lg border bg-card p-4">
+          <ModelUsageChart data={modelUsage} />
+        </div>
+      </div>
+
+      {/* Lines Changed (Stacked Bar Chart) */}
+      <div className="rounded-lg border bg-card p-4">
+        <LinesAreaChart data={initialData.dailyLines} />
+      </div>
+
+      {/* Team Members Table */}
+      <div className={`rounded-lg border bg-card p-4 ${isLoading ? "opacity-50" : ""}`}>
+        <TeamMembersTable
+          members={members}
+          membersDailyActivity={membersDailyActivity}
+          membersAgentUsage={membersAgentUsage}
+          period={period}
+        />
+      </div>
+    </div>
+  );
+}
+
+// =============================================================================
+// Team Summary Component (no cost metrics)
+// =============================================================================
+
+interface TeamSummaryProps {
+  period: Period;
+  sessionCount: number;
+  linesAdded: number;
+  linesRemoved: number;
+  linesModified: number;
+}
+
+function getPeriodLabel(period: Period): string {
+  switch (period) {
+    case "today":
+      return "Today";
+    case "week":
+      return "This Week";
+    case "month":
+      return "This Month";
+  }
+}
+
+function TeamSummary({ period, sessionCount, linesAdded, linesRemoved, linesModified }: TeamSummaryProps) {
+  if (sessionCount === 0) {
+    return (
+      <div>
+        <div className="text-sm text-muted-foreground">{getPeriodLabel(period)}</div>
+        <div className="mt-2 text-center text-muted-foreground">No activity yet</div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="font-mono text-lg">
+        <span className="text-muted-foreground">{getPeriodLabel(period)}:</span>
+        <span className="ml-2 font-semibold">{sessionCount} transcripts</span>
+      </div>
+      <div className="mt-1 font-mono text-sm text-muted-foreground">
+        <span className={linesAdded > 0 ? "text-green-500" : "text-muted-foreground"}>
+          +{formatCompactNumber(linesAdded)}
+        </span>
+        <span className="mx-2">·</span>
+        <span className={linesRemoved > 0 ? "text-red-500" : "text-muted-foreground"}>
+          -{formatCompactNumber(linesRemoved)}
+        </span>
+        <span className="mx-2">·</span>
+        <span className={linesModified > 0 ? "text-yellow-500" : "text-muted-foreground"}>
+          ~{formatCompactNumber(linesModified)}
+        </span>
+        <span className="ml-1">lines</span>
+      </div>
+    </div>
+  );
+}
+
+// =============================================================================
+// Activity Line Chart Component
+// =============================================================================
+
+import { Area, AreaChart, XAxis, YAxis, ResponsiveContainer, Tooltip, BarChart, Bar } from "recharts";
+
+interface DayActivity {
+  date: string;
+  count: number;
+}
+
+interface ActivityLineChartProps {
+  data: DayActivity[];
+}
+
+function ActivityLineChart({ data }: ActivityLineChartProps) {
+  // Show last 30 days for the line chart
+  const last30 = data.slice(-30);
+
+  if (last30.every((d) => d.count === 0)) {
+    return (
+      <div>
+        <div className="mb-3 text-sm text-muted-foreground">Activity Trend</div>
+        <div className="flex h-32 items-center justify-center text-muted-foreground">
+          No activity in the last 30 days
+        </div>
+      </div>
+    );
+  }
+
+  // Find max for better Y scaling
+  const maxCount = Math.max(...last30.map((d) => d.count), 1);
+
+  return (
+    <div>
+      <div className="mb-3 text-sm text-muted-foreground">Activity Trend (last 30 days)</div>
+      <ResponsiveContainer width="100%" height={140}>
+        <AreaChart data={last30} margin={{ top: 10, right: 10, left: 0, bottom: 5 }}>
+          <defs>
+            <linearGradient id="activityGradient" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="5%" stopColor="#ffffff" stopOpacity={0.4} />
+              <stop offset="95%" stopColor="#ffffff" stopOpacity={0.05} />
+            </linearGradient>
+          </defs>
+          <XAxis
+            dataKey="date"
+            tick={{ fontSize: 10, fill: "rgba(255,255,255,0.5)" }}
+            tickFormatter={(d) => new Date(d).toLocaleDateString("en-US", { month: "short", day: "numeric" })}
+            tickLine={false}
+            axisLine={false}
+            interval="preserveStartEnd"
+          />
+          <YAxis hide domain={[0, Math.max(maxCount * 1.2, 5)]} />
+          <Tooltip
+            content={({ active, payload }) => {
+              if (!active || !payload?.[0]) return null;
+              const d = payload[0].payload as DayActivity;
+              return (
+                <div className="rounded border border-border bg-popover px-2 py-1 text-xs shadow-lg">
+                  {new Date(d.date).toLocaleDateString("en-US", { month: "short", day: "numeric" })}:{" "}
+                  <strong>{d.count}</strong> session{d.count !== 1 ? "s" : ""}
+                </div>
+              );
+            }}
+          />
+          <Area
+            type="monotone"
+            dataKey="count"
+            stroke="#ffffff"
+            strokeWidth={2}
+            fill="url(#activityGradient)"
+            dot={{ fill: "#ffffff", strokeWidth: 0, r: 3 }}
+            activeDot={{ fill: "#ffffff", strokeWidth: 0, r: 5 }}
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+// =============================================================================
+// Agent Sparklines Component
+// =============================================================================
+
+interface DailyAgentData {
+  date: string;
+  agent: string;
+  count: number;
+}
+
+interface AgentSparklinesProps {
+  data: DailyAgentData[];
+  period: Period;
+}
+
+function getPeriodDaysCount(period: Period): number {
+  switch (period) {
+    case "today":
+      return 1;
+    case "week":
+      return 7;
+    case "month":
+      return 30;
+  }
+}
+
+function getPeriodDescription(period: Period): string {
+  switch (period) {
+    case "today":
+      return "today";
+    case "week":
+      return "last 7 days";
+    case "month":
+      return "last 30 days";
+  }
+}
+
+function AgentSparklines({ data, period }: AgentSparklinesProps) {
+  const days = getPeriodDaysCount(period);
+
+  // Generate all dates for the period
+  const today = new Date();
+  const allDates: string[] = [];
+  for (let i = days - 1; i >= 0; i--) {
+    const date = new Date(today);
+    date.setDate(date.getDate() - i);
+    allDates.push(date.toISOString().split("T")[0]);
+  }
+
+  // Group data by agent
+  const agentMap = new Map<string, Map<string, number>>();
+
+  data.forEach((d) => {
+    if (!agentMap.has(d.agent)) {
+      agentMap.set(d.agent, new Map());
+    }
+    agentMap.get(d.agent)!.set(d.date, d.count);
+  });
+
+  // Build sparkline data per agent
+  const agents = Array.from(agentMap.keys()).sort((a, b) => {
+    // Sort by total count descending
+    const totalA = Array.from(agentMap.get(a)!.values()).reduce((s, v) => s + v, 0);
+    const totalB = Array.from(agentMap.get(b)!.values()).reduce((s, v) => s + v, 0);
+    return totalB - totalA;
+  });
+
+  if (agents.length === 0) {
+    return (
+      <div>
+        <div className="mb-3 text-sm text-muted-foreground">Agent Activity</div>
+        <div className="flex h-16 items-center justify-center text-muted-foreground">No agent data</div>
+      </div>
+    );
+  }
+
+  const agentRows = agents.map((agent) => {
+    const counts = allDates.map((d) => agentMap.get(agent)?.get(d) || 0);
+    const total = counts.reduce((s, v) => s + v, 0);
+    const max = Math.max(...counts, 1);
+
+    return { agent, counts, total, max };
+  });
+
+  return (
+    <div>
+      <div className="mb-3 text-sm text-muted-foreground">Agent Activity ({getPeriodDescription(period)})</div>
+      <div className="space-y-2">
+        {agentRows.map(({ agent, counts, total, max }) => {
+          return (
+            <div key={agent} className="flex items-center gap-2">
+              <span className="w-20 shrink-0 truncate font-mono text-xs text-muted-foreground">
+                {getAgentDisplayName(agent)}
+              </span>
+              <div className="h-4 flex-1">
+                <svg width="100%" height="100%" preserveAspectRatio="none">
+                  {counts.map((c, i) => {
+                    const height = max > 0 ? (c / max) * 100 : 0;
+                    const barWidth = 100 / counts.length;
+                    return (
+                      <rect
+                        key={i}
+                        x={`${i * barWidth}%`}
+                        y={`${100 - Math.max(height, 5)}%`}
+                        width={`${barWidth}%`}
+                        height={`${Math.max(height, 5)}%`}
+                        fill="rgba(255,255,255,0.6)"
+                      />
+                    );
+                  })}
+                </svg>
+              </div>
+              <span className="w-8 shrink-0 text-right font-mono text-xs text-muted-foreground">{total}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// =============================================================================
+// DailyLines interface (used by LinesAreaChart)
+// =============================================================================
+
+interface DailyLines {
+  date: string;
+  added: number;
+  removed: number;
+  modified: number;
+}
+
+// =============================================================================
+// Lines Changed Chart (Stacked Bar with Log Scale)
+// =============================================================================
+
+interface LinesAreaChartProps {
+  data: DailyLines[];
+}
+
+function LinesAreaChart({ data }: LinesAreaChartProps) {
+  const last30 = data.slice(-30);
+
+  const totalAdded = last30.reduce((s, d) => s + d.added, 0);
+  const totalRemoved = last30.reduce((s, d) => s + d.removed, 0);
+  const totalModified = last30.reduce((s, d) => s + d.modified, 0);
+
+  if (totalAdded === 0 && totalRemoved === 0 && totalModified === 0) {
+    return (
+      <div>
+        <div className="mb-3 text-sm text-muted-foreground">Lines Changed</div>
+        <div className="flex h-32 items-center justify-center text-muted-foreground">
+          No lines data in the last 30 days
+        </div>
+      </div>
+    );
+  }
+
+  // Add log-scaled values for better visualization
+  const chartData = last30.map((d) => ({
+    ...d,
+    // Use log scale: log(1 + value) to handle zeros
+    addedLog: Math.log10(1 + d.added),
+    removedLog: Math.log10(1 + d.removed),
+    modifiedLog: Math.log10(1 + d.modified),
+  }));
+
+  // Calculate max log value for Y axis domain
+  const maxLogValue = Math.max(...chartData.map((d) => d.addedLog + d.removedLog + d.modifiedLog), 1);
+  const maxTick = Math.min(Math.ceil(maxLogValue) + 1, 4);
+
+  return (
+    <div>
+      <div className="mb-3 text-sm text-muted-foreground">Lines Changed</div>
+      <ResponsiveContainer width="100%" height={180}>
+        <BarChart data={chartData} margin={{ top: 5, right: 10, left: 10, bottom: 5 }}>
+          <XAxis
+            dataKey="date"
+            tick={{ fontSize: 9, fill: "rgba(255,255,255,0.5)" }}
+            tickFormatter={(d) => new Date(d).toLocaleDateString("en-US", { month: "short", day: "numeric" })}
+            tickLine={false}
+            axisLine={false}
+            interval="preserveStartEnd"
+          />
+          <YAxis hide domain={[0, maxTick]} />
+          <Tooltip
+            content={({ active, payload, label }) => {
+              if (!active || !payload?.length) return null;
+              const original = last30.find((d) => d.date === label);
+              return (
+                <div className="rounded border border-border bg-popover px-2 py-1 text-xs shadow-lg">
+                  <div className="mb-1">
+                    {new Date(label).toLocaleDateString("en-US", { month: "short", day: "numeric" })}
+                  </div>
+                  <div className="text-green-500">+{original?.added ?? 0} added</div>
+                  <div className="text-red-500">-{original?.removed ?? 0} removed</div>
+                  <div className="text-yellow-500">~{original?.modified ?? 0} modified</div>
+                </div>
+              );
+            }}
+          />
+          <Bar dataKey="addedLog" stackId="a" fill="#22c55e" radius={[0, 0, 0, 0]} />
+          <Bar dataKey="removedLog" stackId="a" fill="#ef4444" radius={[0, 0, 0, 0]} />
+          <Bar dataKey="modifiedLog" stackId="a" fill="#eab308" radius={[2, 2, 0, 0]} />
+        </BarChart>
+      </ResponsiveContainer>
+      <div className="mt-2 flex justify-center gap-4 text-xs">
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-2 w-3 rounded-sm bg-green-500"></span> Added
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-2 w-3 rounded-sm bg-red-500"></span> Removed
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-2 w-3 rounded-sm bg-yellow-500"></span> Modified
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// =============================================================================
+// Model Usage Bar Chart Component
+// =============================================================================
+
+// BarChart and Bar imported above
+
+interface ModelUsage {
+  model: string;
+  messageCount: number;
+}
+
+interface ModelUsageChartProps {
+  data: ModelUsage[];
+}
+
+function ModelUsageChart({ data }: ModelUsageChartProps) {
+  if (data.length === 0) {
+    return (
+      <div>
+        <div className="mb-3 text-sm text-muted-foreground">Prompts by Model</div>
+        <div className="flex h-32 items-center justify-center text-muted-foreground">No model data</div>
+      </div>
+    );
+  }
+
+  // Sort by count descending and take top 5
+  const sorted = [...data].sort((a, b) => b.messageCount - a.messageCount).slice(0, 5);
+  const maxCount = sorted[0]?.messageCount || 1;
+  const barWidth = 20; // number of block characters
+
+  return (
+    <div>
+      <div className="mb-3 text-sm text-muted-foreground">Prompts by Model</div>
+      <div className="space-y-1 font-mono text-sm">
+        {sorted.map((item) => {
+          const filledBlocks = Math.round((item.messageCount / maxCount) * barWidth);
+          const emptyBlocks = barWidth - filledBlocks;
+          return (
+            <div key={item.model} className="flex items-center gap-3">
+              <span className="w-36 truncate text-foreground/90">{getModelDisplayName(item.model)}</span>
+              <span className="text-foreground/70">
+                {"█".repeat(filledBlocks)}
+                <span className="text-foreground/20">{"░".repeat(emptyBlocks)}</span>
+              </span>
+              <span className="w-10 text-right text-foreground/50">{formatCompactNumber(item.messageCount)}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// =============================================================================
+// Team Members Table Component (Enhanced with Sparklines)
+// =============================================================================
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { ClaudeCodeIcon, CodexIcon, OpenCodeIcon } from "@/components/icons/source-icons";
+
+interface TeamMember {
+  userId: string;
+  name: string;
+  image: string | null;
+  transcriptCount: number;
+  linesAdded: number;
+  linesRemoved: number;
+  linesModified: number;
+  commitCount: number;
+}
+
+interface MemberDailyActivity {
+  userId: string;
+  date: string;
+  count: number;
+}
+
+interface MemberAgentUsage {
+  userId: string;
+  agent: string;
+  count: number;
+}
+
+interface TeamMembersTableProps {
+  members: TeamMember[];
+  membersDailyActivity: MemberDailyActivity[];
+  membersAgentUsage: MemberAgentUsage[];
+  period: Period;
+}
+
+// Agent icon components
+const AGENT_ICONS: Record<string, React.FC<{ className?: string }>> = {
+  "claude-code": ClaudeCodeIcon,
+  codex: CodexIcon,
+  opencode: OpenCodeIcon,
+};
+
+function TeamMembersTable({ members, membersDailyActivity, membersAgentUsage, period }: TeamMembersTableProps) {
+  if (members.length === 0) {
+    return (
+      <div>
+        <div className="mb-3 text-sm text-muted-foreground">Team Members</div>
+        <div className="text-center text-muted-foreground">No members found</div>
+      </div>
+    );
+  }
+
+  // Sort by transcript count descending
+  const sorted = [...members].sort((a, b) => b.transcriptCount - a.transcriptCount);
+
+  // Get days for period
+  const days = period === "today" ? 1 : period === "week" ? 7 : 30;
+
+  // Generate all dates for sparklines
+  const today = new Date();
+  const allDates: string[] = [];
+  for (let i = days - 1; i >= 0; i--) {
+    const date = new Date(today);
+    date.setDate(date.getDate() - i);
+    allDates.push(date.toISOString().split("T")[0]);
+  }
+
+  // Group daily activity by user
+  const activityByUser = new Map<string, Map<string, number>>();
+  membersDailyActivity.forEach((d) => {
+    if (!activityByUser.has(d.userId)) {
+      activityByUser.set(d.userId, new Map());
+    }
+    activityByUser.get(d.userId)!.set(d.date, d.count);
+  });
+
+  // Group agent usage by user
+  const agentsByUser = new Map<string, { agent: string; count: number }[]>();
+  membersAgentUsage.forEach((d) => {
+    if (!agentsByUser.has(d.userId)) {
+      agentsByUser.set(d.userId, []);
+    }
+    agentsByUser.get(d.userId)!.push({ agent: d.agent, count: d.count });
+  });
+
+  return (
+    <div>
+      <div className="mb-3 text-sm text-muted-foreground">Team Members</div>
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b text-xs text-muted-foreground">
+            <th className="pb-2 text-left font-normal">User</th>
+            <th className="pb-2 pl-3 text-left font-normal">Activity</th>
+            <th className="pb-2 pl-3 text-left font-normal">Agents</th>
+            <th className="pb-2 text-right font-normal">Sessions</th>
+            <th className="pb-2 text-right font-normal">Lines</th>
+            <th className="pb-2 text-right font-normal">Commits</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((member) => {
+            // Build sparkline data for this member
+            const userActivity = activityByUser.get(member.userId) || new Map();
+            const counts = allDates.map((d) => userActivity.get(d) || 0);
+            const maxCount = Math.max(...counts, 1);
+
+            // Build agent breakdown for this member
+            const userAgents = agentsByUser.get(member.userId) || [];
+            const sortedAgents = [...userAgents].sort((a, b) => b.count - a.count);
+
+            return (
+              <tr key={member.userId} className="border-b border-border/50">
+                <td className="py-2">
+                  <div className="flex items-center gap-2">
+                    <Avatar className="h-6 w-6">
+                      <AvatarImage src={member.image || undefined} />
+                      <AvatarFallback className="text-[10px]">{member.name.slice(0, 2).toUpperCase()}</AvatarFallback>
+                    </Avatar>
+                    <span className="max-w-[120px] truncate">{member.name}</span>
+                  </div>
+                </td>
+                <td className="py-2 pl-3">
+                  {/* Activity Sparkline - SVG mini bar chart */}
+                  {counts.every((c) => c === 0) ? (
+                    <span className="text-muted-foreground/50">—</span>
+                  ) : (
+                    <div className="h-4 w-20">
+                      <svg width="100%" height="100%" preserveAspectRatio="none">
+                        {counts.map((c, i) => {
+                          const height = maxCount > 0 ? (c / maxCount) * 100 : 0;
+                          const barWidth = 100 / counts.length;
+                          return (
+                            <rect
+                              key={i}
+                              x={`${i * barWidth}%`}
+                              y={`${100 - height}%`}
+                              width={`${barWidth}%`}
+                              height={`${height}%`}
+                              fill={c > 0 ? "rgba(255,255,255,0.6)" : "rgba(255,255,255,0.1)"}
+                            />
+                          );
+                        })}
+                      </svg>
+                    </div>
+                  )}
+                </td>
+                <td className="py-2 pl-3">
+                  {/* Agent Breakdown - real icons with counts */}
+                  {sortedAgents.length === 0 ? (
+                    <span className="text-muted-foreground/50">—</span>
+                  ) : (
+                    <div className="flex items-center gap-3 font-mono text-xs">
+                      {sortedAgents.slice(0, 3).map((a) => {
+                        const IconComponent = AGENT_ICONS[a.agent];
+                        return (
+                          <span
+                            key={a.agent}
+                            className="flex items-center gap-1 text-foreground/70"
+                            title={getAgentDisplayName(a.agent)}
+                          >
+                            {IconComponent ? (
+                              <IconComponent className="h-3.5 w-3.5 text-foreground/60" />
+                            ) : (
+                              <span className="text-foreground/50">○</span>
+                            )}
+                            <span>{a.count}</span>
+                          </span>
+                        );
+                      })}
+                    </div>
+                  )}
+                </td>
+                <td className="py-2 text-right">{member.transcriptCount}</td>
+                <td className="py-2 text-right">
+                  <span className={member.linesAdded > 0 ? "text-green-500" : "text-muted-foreground"}>
+                    +{formatCompactNumber(member.linesAdded)}
+                  </span>
+                  <span className="mx-1 text-muted-foreground">/</span>
+                  <span className={member.linesRemoved > 0 ? "text-red-500" : "text-muted-foreground"}>
+                    -{formatCompactNumber(member.linesRemoved)}
+                  </span>
+                </td>
+                <td className="py-2 text-right">{member.commitCount}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/packages/web/src/routes/_app/app/team/index.tsx
+++ b/packages/web/src/routes/_app/app/team/index.tsx
@@ -21,9 +21,9 @@ import {
   getTeam,
   leaveTeam,
   removeMember,
-} from "../../../lib/server-functions";
+} from "@/lib/server-functions";
 
-export const Route = createFileRoute("/_app/app/team")({
+export const Route = createFileRoute("/_app/app/team/")({
   loader: async () => {
     const [team, session] = await Promise.all([getTeam(), getSession()]);
     return { team, session };


### PR DESCRIPTION
Team Dashboard at /app/team/dashboard:
- Team summary with lines changed (added/removed/modified)
- Activity trend chart (sessions over 30 days)
- Agent activity sparklines per agent
- Prompts by model (terminal-style bar chart)
- Lines changed stacked bars (log scale)
- Team members table with activity sparklines and agent breakdown

Technical:
- New queries for team-scoped metrics
- Server functions with auth and membership checks
- Period selector (today/week/month)
- Responsive empty states
- Shared formatters in lib/formatters.ts
- Monochrome theme with diff colors