### PR TITLE
feat: add dev-login for local development

### DIFF
--- a/packages/web/src/lib/server-functions.ts
+++ b/packages/web/src/lib/server-functions.ts
@@ -31,11 +31,33 @@ const generateId = () => getCuidGenerator()();
 /**
  * Get the current authenticated user's ID
  * Throws if not authenticated
+ *
+ * DEV MODE: When DEV_AUTH_ENABLED=true and dev-user-email cookie is set,
+ * bypasses real auth and returns the user ID for that email.
  */
 async function getAuthenticatedUserId() {
-  const auth = createAuth();
   const headers = getRequestHeaders();
 
+  // DEV MODE: Bypass auth when DEV_AUTH_ENABLED=true
+  if (env.DEV_AUTH_ENABLED === "true") {
+    const cookieHeader = headers.get("cookie") || "";
+    const devEmailMatch = cookieHeader.match(/dev-user-email=([^;]+)/);
+
+    if (devEmailMatch) {
+      const devEmail = decodeURIComponent(devEmailMatch[1]);
+      const db = createDrizzle(env.DB);
+      const users = await db.query.user.findMany({
+        where: (user, { eq }) => eq(user.email, devEmail),
+        limit: 1,
+      });
+
+      if (users.length > 0) {
+        return users[0].id;
+      }
+    }
+  }
+
+  const auth = createAuth();
   const session = await auth.api.getSession({
     headers,
   });
@@ -51,12 +73,53 @@ async function getAuthenticatedUserId() {
 /**
  * Server function to fetch the current session
  * Returns null if not authenticated
+ *
+ * DEV MODE: When DEV_AUTH_ENABLED=true and dev-user-email cookie is set,
+ * bypasses real auth and returns a session for that user.
  */
 export const getSession = createServerFn({ method: "GET" }).handler(async () => {
   try {
+    const headers = getRequestHeaders();
+
+    // DEV MODE: Bypass auth when DEV_AUTH_ENABLED=true
+    if (env.DEV_AUTH_ENABLED === "true") {
+      const cookieHeader = headers.get("cookie") || "";
+      const devEmailMatch = cookieHeader.match(/dev-user-email=([^;]+)/);
+
+      if (devEmailMatch) {
+        const devEmail = decodeURIComponent(devEmailMatch[1]);
+        logger.warn("🚨 DEV AUTH BYPASS - Using dev-user-email cookie", { email: devEmail });
+
+        const db = createDrizzle(env.DB);
+        const users = await db.query.user.findMany({
+          where: (user, { eq }) => eq(user.email, devEmail),
+          limit: 1,
+        });
+
+        if (users.length > 0) {
+          const devUser = users[0];
+          const role = await queries.getUserRole(db, devUser.id).catch(() => "user");
+
+          return {
+            user: {
+              id: devUser.id,
+              email: devUser.email,
+              name: devUser.name,
+              image: devUser.image,
+              role: role ?? "user",
+            },
+            session: {
+              id: "dev-session",
+              expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+            },
+          };
+        }
+      }
+    }
+
     const auth = createAuth();
     const session = await auth.api.getSession({
-      headers: getRequestHeaders(),
+      headers,
     });
 
     if (!session?.user) {

--- a/packages/web/src/routeTree.gen.ts
+++ b/packages/web/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as WaitlistRouteImport } from './routes/waitlist'
 import { Route as AppRouteImport } from './routes/_app'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as AuthDevLoginRouteImport } from './routes/auth.dev-login'
 import { Route as AuthSplatRouteImport } from './routes/auth.$'
 import { Route as ApiTunnelRouteImport } from './routes/api/tunnel'
 import { Route as ApiTranscriptsRouteImport } from './routes/api/transcripts'
@@ -42,6 +43,11 @@ const AppRoute = AppRouteImport.update({
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AuthDevLoginRoute = AuthDevLoginRouteImport.update({
+  id: '/auth/dev-login',
+  path: '/auth/dev-login',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AuthSplatRoute = AuthSplatRouteImport.update({
@@ -139,6 +145,7 @@ export interface FileRoutesByFullPath {
   '/api/transcripts': typeof ApiTranscriptsRouteWithChildren
   '/api/tunnel': typeof ApiTunnelRoute
   '/auth/$': typeof AuthSplatRoute
+  '/auth/dev-login': typeof AuthDevLoginRoute
   '/app/admin': typeof AppAppAdminRoute
   '/app/device': typeof AppAppDeviceRoute
   '/app/team': typeof AppAppTeamRoute
@@ -160,6 +167,7 @@ export interface FileRoutesByTo {
   '/api/transcripts': typeof ApiTranscriptsRouteWithChildren
   '/api/tunnel': typeof ApiTunnelRoute
   '/auth/$': typeof AuthSplatRoute
+  '/auth/dev-login': typeof AuthDevLoginRoute
   '/app/admin': typeof AppAppAdminRoute
   '/app/device': typeof AppAppDeviceRoute
   '/app/team': typeof AppAppTeamRoute
@@ -183,6 +191,7 @@ export interface FileRoutesById {
   '/api/transcripts': typeof ApiTranscriptsRouteWithChildren
   '/api/tunnel': typeof ApiTunnelRoute
   '/auth/$': typeof AuthSplatRoute
+  '/auth/dev-login': typeof AuthDevLoginRoute
   '/_app/app/admin': typeof AppAppAdminRoute
   '/_app/app/device': typeof AppAppDeviceRoute
   '/_app/app/team': typeof AppAppTeamRoute
@@ -206,6 +215,7 @@ export interface FileRouteTypes {
     | '/api/transcripts'
     | '/api/tunnel'
     | '/auth/$'
+    | '/auth/dev-login'
     | '/app/admin'
     | '/app/device'
     | '/app/team'
@@ -227,6 +237,7 @@ export interface FileRouteTypes {
     | '/api/transcripts'
     | '/api/tunnel'
     | '/auth/$'
+    | '/auth/dev-login'
     | '/app/admin'
     | '/app/device'
     | '/app/team'
@@ -249,6 +260,7 @@ export interface FileRouteTypes {
     | '/api/transcripts'
     | '/api/tunnel'
     | '/auth/$'
+    | '/auth/dev-login'
     | '/_app/app/admin'
     | '/_app/app/device'
     | '/_app/app/team'
@@ -272,6 +284,7 @@ export interface RootRouteChildren {
   ApiTranscriptsRoute: typeof ApiTranscriptsRouteWithChildren
   ApiTunnelRoute: typeof ApiTunnelRoute
   AuthSplatRoute: typeof AuthSplatRoute
+  AuthDevLoginRoute: typeof AuthDevLoginRoute
   ApiAuthSplatRoute: typeof ApiAuthSplatRoute
   ApiBlobsSha256Route: typeof ApiBlobsSha256Route
   ApiAdminTranscriptUnifiedIdRoute: typeof ApiAdminTranscriptUnifiedIdRoute
@@ -298,6 +311,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/auth/dev-login': {
+      id: '/auth/dev-login'
+      path: '/auth/dev-login'
+      fullPath: '/auth/dev-login'
+      preLoaderRoute: typeof AuthDevLoginRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/auth/$': {
@@ -467,6 +487,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiTranscriptsRoute: ApiTranscriptsRouteWithChildren,
   ApiTunnelRoute: ApiTunnelRoute,
   AuthSplatRoute: AuthSplatRoute,
+  AuthDevLoginRoute: AuthDevLoginRoute,
   ApiAuthSplatRoute: ApiAuthSplatRoute,
   ApiBlobsSha256Route: ApiBlobsSha256Route,
   ApiAdminTranscriptUnifiedIdRoute: ApiAdminTranscriptUnifiedIdRoute,

--- a/packages/web/src/routes/auth.dev-login.ts
+++ b/packages/web/src/routes/auth.dev-login.ts
@@ -1,0 +1,106 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { env } from "cloudflare:workers";
+import { createDrizzle } from "../db";
+import { user } from "../db/schema";
+import { eq } from "drizzle-orm";
+import { logger } from "../lib/logger";
+
+/**
+ * Development-only login route that bypasses OAuth
+ *
+ * Usage: /auth/dev-login?email=test@example.com
+ *
+ * SECURITY: Only works when DEV_AUTH_ENABLED=true in environment
+ * This should NEVER be enabled in production
+ *
+ * Sets a dev-user-email cookie that getSession() checks to bypass real auth.
+ */
+export const Route = createFileRoute("/auth/dev-login")({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        // Safety check: Only allow in development
+        const devAuthEnabled = env.DEV_AUTH_ENABLED === "true";
+        const isLocalhost = env.WEB_URL?.includes("localhost");
+
+        if (!devAuthEnabled) {
+          logger.warn("Dev login attempted but DEV_AUTH_ENABLED is not set");
+          return new Response("Dev login is disabled. Set DEV_AUTH_ENABLED=true in .dev.vars", {
+            status: 403,
+          });
+        }
+
+        if (!isLocalhost) {
+          logger.warn("Dev login attempted on non-localhost URL", { url: env.WEB_URL });
+          return new Response("Dev login only works on localhost", { status: 403 });
+        }
+
+        const url = new URL(request.url);
+        const email = url.searchParams.get("email");
+
+        if (!email) {
+          return new Response(
+            "Usage: /auth/dev-login?email=test@example.com\n\n" +
+              "This will set a cookie that bypasses auth for development.\n" +
+              "The user must exist in the database.",
+            { status: 400, headers: { "Content-Type": "text/plain" } },
+          );
+        }
+
+        logger.warn("🚨 DEV LOGIN USED - This should never happen in production!", { email });
+
+        try {
+          const db = createDrizzle(env.DB);
+
+          // Find user
+          const users = await db.select().from(user).where(eq(user.email, email)).limit(1);
+          let targetUser = users[0];
+
+          // Create user if doesn't exist
+          if (!targetUser) {
+            const newUserId = crypto.randomUUID();
+            await db.insert(user).values({
+              id: newUserId,
+              email: email,
+              name: email.split("@")[0],
+              emailVerified: true,
+              role: "user",
+            });
+            const newUsers = await db.select().from(user).where(eq(user.id, newUserId)).limit(1);
+            targetUser = newUsers[0];
+            logger.info("Created new user for dev login", { email, userId: newUserId });
+          }
+
+          if (!targetUser) {
+            return new Response("Failed to find or create user", { status: 500 });
+          }
+
+          logger.info("Dev login successful", {
+            userId: targetUser.id,
+            email: targetUser.email,
+            name: targetUser.name,
+          });
+
+          // Set dev-user-email cookie and redirect to app
+          const headers = new Headers();
+          headers.set("Location", "/app");
+          headers.set(
+            "Set-Cookie",
+            `dev-user-email=${encodeURIComponent(email)}; Path=/; HttpOnly; SameSite=Lax; Max-Age=${30 * 24 * 60 * 60}`,
+          );
+
+          return new Response(null, {
+            status: 302,
+            headers,
+          });
+        } catch (error) {
+          logger.error("Dev login failed", {
+            error: error instanceof Error ? error.message : String(error),
+            stack: error instanceof Error ? error.stack : undefined,
+          });
+          return new Response(`Dev login failed: ${error}`, { status: 500 });
+        }
+      },
+    },
+  },
+});


### PR DESCRIPTION
Adds /auth/dev-login route for bypassing OAuth during local development.

Usage: /auth/dev-login?email=user@example.com

Security:
- Only works when DEV_AUTH_ENABLED=true in environment
- Sets dev-user-email cookie that getSession() checks
- Should NEVER be enabled in production