### PR TITLE
Transcripts: Surface and collapse steering messages

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -4,6 +4,10 @@ description: "Product updates and announcements"
 ---
 
 <Update label="September 8, 2026">
+## Steering Messages
+
+- Claude Code steering prompts now appear between collapsible groups of working steps, with shareable message links and a quieter presentation outside the prompts sidebar (#29) thanks @MSch
+
 ## Team Dashboard and Landing Page Fixes
 
 - Team changes now refresh the dashboard immediately, with controls staying busy until the update completes; the selected period persists in the URL (#42) thanks @souritrakar

--- a/packages/e2e/tests/authenticated/steering.e2e.ts
+++ b/packages/e2e/tests/authenticated/steering.e2e.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "@playwright/test";
+import { seedSteeringTranscript } from "../../utils/steering-transcript";
+
+test("ordinary steps expand with one click", async ({ page }) => {
+  const id = await seedSteeringTranscript(false);
+  await page.goto(`/app/logs/${id}`);
+  await page.waitForLoadState("networkidle");
+  await page.getByRole("button", { name: "4 steps hidden", exact: true }).click();
+  await expect(page.getByText("Inspecting the workspace.", { exact: true })).toBeVisible();
+  await expect(page.getByText("Checking the preview.", { exact: true })).toBeVisible();
+});
+
+test("steering messages separate nested steps and their permalinks survive reload", async ({ page }) => {
+  const id = await seedSteeringTranscript();
+  await page.goto(`/app/logs/${id}`);
+  await page.waitForLoadState("networkidle");
+  await expect(page.locator("aside").getByText("Use the local preview server.")).toHaveCount(0);
+  await page.getByRole("button", { name: "4 steps, 1 steering message hidden", exact: true }).click();
+  const steeringMessage = page.locator("#msg-4");
+  await expect(steeringMessage).toContainText("Use the local preview server.");
+  await expect(page.getByText("Inspecting the workspace.", { exact: true })).not.toBeVisible();
+  const nestedGroups = page.getByRole("button", { name: "2 steps hidden", exact: true });
+  await expect(nestedGroups).toHaveCount(2);
+  await nestedGroups.first().click();
+  await expect(page.getByText("Inspecting the workspace.", { exact: true })).toBeVisible();
+  await expect(page.getByText("Checking the preview.", { exact: true })).not.toBeVisible();
+
+  await steeringMessage.hover();
+  await steeringMessage.getByTitle("Permalink").click();
+  await expect(page).toHaveURL(new RegExp(`/app/logs/${id}#msg-4$`));
+  await expect(page.locator("aside input")).toHaveValue(new RegExp("#msg-4$"));
+  await page.reload();
+  await expect(steeringMessage).toBeVisible();
+  await expect(steeringMessage).toBeInViewport();
+  await expect(page.getByRole("button", { name: "2 steps hidden", exact: true })).toHaveCount(2);
+});

--- a/packages/e2e/utils/steering-transcript.ts
+++ b/packages/e2e/utils/steering-transcript.ts
@@ -1,0 +1,69 @@
+import { convertClaudeCodeTranscript } from "../../shared/src/claudecode";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { getTestDb } from "./db";
+import { createTranscript, testId } from "./factories";
+
+export async function seedSteeringTranscript(includeSteering = true) {
+  const id = testId();
+  const records: Record<string, unknown>[] = [
+    { type: "user", message: { role: "user", content: "Build the dashboard" } },
+    {
+      type: "assistant",
+      message: { role: "assistant", content: [{ type: "text", text: "Inspecting the workspace." }] },
+    },
+    {
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "tool-1", name: "Bash", input: { command: "ls" } }],
+      },
+    },
+    ...(includeSteering
+      ? [
+          {
+            type: "attachment",
+            attachment: { type: "queued_command", commandMode: "prompt", prompt: "Use the local preview server." },
+          },
+        ]
+      : []),
+    { type: "assistant", message: { role: "assistant", content: [{ type: "text", text: "Checking the preview." }] } },
+    {
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "tool-2", name: "Bash", input: { command: "pwd" } }],
+      },
+    },
+    { type: "assistant", message: { role: "assistant", content: [{ type: "text", text: "Dashboard complete." }] } },
+    { type: "user", message: { role: "user", content: "Explain the changes" } },
+    { type: "assistant", message: { role: "assistant", content: [{ type: "text", text: "Everything is ready." }] } },
+  ];
+  const result = convertClaudeCodeTranscript(
+    records.map((record, index) => ({
+      ...record,
+      uuid: `${id}-${index}`,
+      sessionId: `steering-${id}`,
+      timestamp: new Date(Date.UTC(2026, 0, 1, 0, 0, index)).toISOString(),
+      cwd: "/tmp/steering-test",
+    })),
+  );
+  if (!result) throw new Error("Failed to convert steering fixture");
+
+  const transcript = createTranscript(id, {
+    transcriptId: result.transcript.id,
+    preview: result.transcript.preview,
+    messageCount: result.transcript.messageCount,
+    repoId: null,
+  });
+  const storageDirectory = path.resolve(import.meta.dirname!, "../../server/.data/storage/private/test-user-id");
+  await mkdir(storageDirectory, { recursive: true });
+  await writeFile(path.join(storageDirectory, `${result.transcript.id}.json`), JSON.stringify(result.transcript));
+  const { db, sqlite, schema } = getTestDb();
+  try {
+    db.insert(schema.transcripts).values(transcript).run();
+  } finally {
+    sqlite.close();
+  }
+  return transcript.id;
+}

--- a/packages/server/src/lib/message-segments.test.ts
+++ b/packages/server/src/lib/message-segments.test.ts
@@ -1,0 +1,124 @@
+import type { UnifiedTranscriptMessage } from "@agentlogs/shared/claudecode";
+import { describe, expect, test } from "bun:test";
+import { groupMessagesIntoSegments, isImportantMessage, isSteeringMessage } from "./message-segments";
+
+describe("isImportantMessage", () => {
+  test("keeps only the last assistant message before the next user prompt expanded", () => {
+    const messages = [
+      { type: "agent", text: "First update" },
+      { type: "agent", text: "Last update" },
+      { type: "user", text: "Next prompt" },
+    ] satisfies UnifiedTranscriptMessage[];
+
+    expect(isImportantMessage(messages[0], 0, messages)).toBe(false);
+
+    expect(isImportantMessage(messages[1], 1, messages)).toBe(true);
+  });
+
+  test("collapses operational steps", () => {
+    const messages = [
+      { type: "tool-call", toolName: "Bash" },
+      { type: "thinking", text: "Inspecting logs" },
+    ] satisfies UnifiedTranscriptMessage[];
+
+    expect(isImportantMessage(messages[0], 0, messages)).toBe(false);
+
+    expect(isImportantMessage(messages[1], 1, messages)).toBe(false);
+  });
+
+  test("treats steering prompts as hidden within collapsed sections", () => {
+    const messages = [
+      { type: "user", text: "normal prompt" },
+      { type: "user", text: "use bin/serve locally", variant: "steering" },
+    ] satisfies UnifiedTranscriptMessage[];
+
+    expect(isSteeringMessage(messages[1])).toBe(true);
+    expect(isImportantMessage(messages[1], 1, messages)).toBe(false);
+  });
+});
+
+describe("groupMessagesIntoSegments", () => {
+  test("collapses intermediate assistant updates until the last one before the next user prompt", () => {
+    const messages = [
+      { type: "user", text: "Build the app" },
+      { type: "thinking", text: "Planning" },
+      { type: "agent", text: "Let me start by planning this out and then building it." },
+      { type: "tool-call", toolName: "Bash" },
+      { type: "agent", text: "Good, now let me build the app structure." },
+      { type: "tool-call", toolName: "Write" },
+      { type: "agent", text: "Now the deployment files." },
+      { type: "user", text: "Check with the web browser skill" },
+    ] satisfies UnifiedTranscriptMessage[];
+
+    expect(groupMessagesIntoSegments(messages)).toEqual([
+      { type: "important", message: messages[0], index: 0 },
+      {
+        type: "collapsed",
+        stepCount: 5,
+        steeringCount: 0,
+        items: [
+          {
+            type: "steps",
+            messages: [
+              { message: messages[1], index: 1 },
+              { message: messages[2], index: 2 },
+              { message: messages[3], index: 3 },
+              { message: messages[4], index: 4 },
+              { message: messages[5], index: 5 },
+            ],
+          },
+        ],
+      },
+      { type: "important", message: messages[6], index: 6 },
+      { type: "important", message: messages[7], index: 7 },
+    ]);
+  });
+
+  test("creates two-level collapsed groups around steering messages", () => {
+    const messages = [
+      { type: "user", text: "Build the app" },
+      { type: "thinking", text: "Planning" },
+      { type: "agent", text: "Working through local setup." },
+      { type: "tool-call", toolName: "Bash" },
+      { type: "user", text: "use bin/serve locally", variant: "steering" },
+      { type: "thinking", text: "Checking wrapper" },
+      { type: "tool-call", toolName: "Write" },
+      { type: "agent", text: "Done, inspect it now." },
+      { type: "user", text: "What changed?" },
+    ] satisfies UnifiedTranscriptMessage[];
+    const steeringMessage = messages[4] as UnifiedTranscriptMessage & { type: "user"; variant: "steering" };
+
+    expect(groupMessagesIntoSegments(messages)).toEqual([
+      { type: "important", message: messages[0], index: 0 },
+      {
+        type: "collapsed",
+        stepCount: 5,
+        steeringCount: 1,
+        items: [
+          {
+            type: "steps",
+            messages: [
+              { message: messages[1], index: 1 },
+              { message: messages[2], index: 2 },
+              { message: messages[3], index: 3 },
+            ],
+          },
+          {
+            type: "steering",
+            message: steeringMessage,
+            index: 4,
+          },
+          {
+            type: "steps",
+            messages: [
+              { message: messages[5], index: 5 },
+              { message: messages[6], index: 6 },
+            ],
+          },
+        ],
+      },
+      { type: "important", message: messages[7], index: 7 },
+      { type: "important", message: messages[8], index: 8 },
+    ]);
+  });
+});

--- a/packages/server/src/lib/message-segments.ts
+++ b/packages/server/src/lib/message-segments.ts
@@ -1,0 +1,160 @@
+import type { UnifiedTranscriptMessage } from "@agentlogs/shared/claudecode";
+
+export type MessageReference = { message: UnifiedTranscriptMessage; index: number };
+
+export type CollapsedMessageSegmentItem =
+  | { type: "steps"; messages: MessageReference[] }
+  | {
+      type: "steering";
+      message: UnifiedTranscriptMessage & { type: "user"; variant: "steering" };
+      index: number;
+    };
+
+export type MessageSegment =
+  | { type: "important"; message: UnifiedTranscriptMessage; index: number }
+  | {
+      type: "collapsed";
+      items: CollapsedMessageSegmentItem[];
+      stepCount: number;
+      steeringCount: number;
+    };
+
+/**
+ * Internal fallback filter for user messages that should not render at all.
+ * Most of these are already stripped during ingest.
+ */
+export function isInternalMessage(text: string): boolean {
+  const internalPatterns = [/^<local-command-caveat>.*<\/local-command-caveat>/s];
+  const trimmed = text.trim();
+  return internalPatterns.some((pattern) => pattern.test(trimmed));
+}
+
+export function isSteeringMessage(
+  message: UnifiedTranscriptMessage,
+): message is UnifiedTranscriptMessage & { type: "user"; variant: "steering" } {
+  return message.type === "user" && message.variant === "steering";
+}
+
+/**
+ * Important messages stay expanded.
+ * User and command messages are always important.
+ * Agent messages are important only when they are the last assistant response
+ * before the next user/command prompt, or the final agent message in the log.
+ */
+export function isImportantMessage(
+  message: UnifiedTranscriptMessage,
+  index: number,
+  messages: UnifiedTranscriptMessage[],
+): boolean {
+  if (message.type === "user") {
+    return !isSteeringMessage(message);
+  }
+
+  if (message.type === "command") {
+    return true;
+  }
+
+  if (message.type === "agent") {
+    for (let i = index + 1; i < messages.length; i++) {
+      const nextMsg = messages[i];
+      if (nextMsg.type === "command") {
+        return true;
+      }
+
+      if (isSteeringMessage(nextMsg)) {
+        continue;
+      }
+
+      if (nextMsg.type === "user") {
+        return true;
+      }
+
+      if (nextMsg.type === "agent") {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  return false;
+}
+
+function buildCollapsedSegment(messages: MessageReference[]): MessageSegment | null {
+  if (messages.length === 0) {
+    return null;
+  }
+
+  const items: CollapsedMessageSegmentItem[] = [];
+  let currentStepGroup: MessageReference[] = [];
+  let stepCount = 0;
+  let steeringCount = 0;
+
+  for (const messageRef of messages) {
+    if (isSteeringMessage(messageRef.message)) {
+      if (currentStepGroup.length > 0) {
+        items.push({ type: "steps", messages: currentStepGroup });
+        currentStepGroup = [];
+      }
+
+      items.push({
+        type: "steering",
+        message: messageRef.message,
+        index: messageRef.index,
+      });
+      steeringCount++;
+      continue;
+    }
+
+    currentStepGroup.push(messageRef);
+    stepCount++;
+  }
+
+  if (currentStepGroup.length > 0) {
+    items.push({ type: "steps", messages: currentStepGroup });
+  }
+
+  return {
+    type: "collapsed",
+    items,
+    stepCount,
+    steeringCount,
+  };
+}
+
+export function groupMessagesIntoSegments(messages: UnifiedTranscriptMessage[]): MessageSegment[] {
+  const segments: MessageSegment[] = [];
+  let currentCollapsedGroup: MessageReference[] = [];
+
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i];
+
+    if (message.type === "user" && isInternalMessage(message.text)) {
+      continue;
+    }
+
+    if (isImportantMessage(message, i, messages)) {
+      if (currentCollapsedGroup.length > 0) {
+        const collapsedSegment = buildCollapsedSegment(currentCollapsedGroup);
+        if (collapsedSegment) {
+          segments.push(collapsedSegment);
+        }
+        currentCollapsedGroup = [];
+      }
+
+      segments.push({ type: "important", message, index: i });
+      continue;
+    }
+
+    currentCollapsedGroup.push({ message, index: i });
+  }
+
+  if (currentCollapsedGroup.length > 0) {
+    const collapsedSegment = buildCollapsedSegment(currentCollapsedGroup);
+    if (collapsedSegment) {
+      segments.push(collapsedSegment);
+    }
+  }
+
+  return segments;
+}

--- a/packages/server/src/routes/_app/app/logs.$id.tsx
+++ b/packages/server/src/routes/_app/app/logs.$id.tsx
@@ -62,12 +62,14 @@ import {
   PiIcon,
 } from "../../../components/icons/source-icons";
 import { MarkdownRenderer } from "../../../components/markdown-renderer";
+import { groupMessagesIntoSegments, isInternalMessage } from "../../../lib/message-segments";
 
 import {
   extractImageReferences,
   type ImageReference,
   replaceImageReferencesForDisplay,
 } from "../../../lib/message-utils";
+import { isSteeringMessage } from "../../../lib/message-segments";
 import { deleteTranscript, getTranscript, updateTitle, updateVisibility } from "../../../lib/server-functions";
 
 export const Route = createFileRoute("/_app/app/logs/$id")({
@@ -184,98 +186,12 @@ function formatRepoName(repo: string): { label: string; isGitHub: boolean } {
   return { label: repo, isGitHub: false };
 }
 
-// Check if text is an internal system message (for filtering)
-// Note: Most internal messages are now filtered at ingest time in claudecode.ts
-// This is kept as a fallback for any edge cases
-function isInternalMessage(text: string): boolean {
-  const internalPatterns = [/^<local-command-caveat>.*<\/local-command-caveat>/s];
-  const trimmed = text.trim();
-  return internalPatterns.some((pattern) => pattern.test(trimmed));
-}
-
-// Check if a message is "important" and should be shown expanded
-// Important messages: user messages, last agent response before user message
-function isImportantMessage(
-  message: UnifiedTranscriptMessage,
-  index: number,
-  messages: UnifiedTranscriptMessage[],
-): boolean {
-  // User messages are always important
-  if (message.type === "user") return true;
-
-  // Commands are important (like user prompts)
-  if (message.type === "command") return true;
-
-  // Check if this is the last agent response before a user message
-  if (message.type === "agent") {
-    // Look ahead to find if the next non-thinking, non-tool-call message is a user message
-    for (let i = index + 1; i < messages.length; i++) {
-      const nextMsg = messages[i];
-      if (nextMsg.type === "user" || nextMsg.type === "command") {
-        return true; // This agent message is right before a user prompt
-      }
-      if (nextMsg.type === "agent") {
-        return false; // Another agent message comes first
-      }
-      // Continue past tool-calls and thinking blocks
-    }
-    // If this is the last agent message in the conversation, it's important
-    return true;
-  }
-
-  return false;
-}
-
-// Segment type for grouping messages
-type MessageSegment =
-  | { type: "important"; message: UnifiedTranscriptMessage; index: number }
-  | {
-      type: "collapsed";
-      messages: Array<{ message: UnifiedTranscriptMessage; index: number }>;
-    };
-
-// Group messages into segments of important messages and collapsed steps
-function groupMessagesIntoSegments(messages: UnifiedTranscriptMessage[]): MessageSegment[] {
-  const segments: MessageSegment[] = [];
-  let currentCollapsedGroup: Array<{
-    message: UnifiedTranscriptMessage;
-    index: number;
-  }> = [];
-
-  for (let i = 0; i < messages.length; i++) {
-    const message = messages[i];
-
-    // Skip internal messages
-    if (message.type === "user" && isInternalMessage(message.text)) {
-      continue;
-    }
-
-    if (isImportantMessage(message, i, messages)) {
-      // Flush any pending collapsed group
-      if (currentCollapsedGroup.length > 0) {
-        segments.push({ type: "collapsed", messages: currentCollapsedGroup });
-        currentCollapsedGroup = [];
-      }
-      segments.push({ type: "important", message, index: i });
-    } else {
-      currentCollapsedGroup.push({ message, index: i });
-    }
-  }
-
-  // Flush any remaining collapsed group
-  if (currentCollapsedGroup.length > 0) {
-    segments.push({ type: "collapsed", messages: currentCollapsedGroup });
-  }
-
-  return segments;
-}
-
 // Get user messages with their indices for navigation
 function getUserMessagesWithIndices(messages: UnifiedTranscriptMessage[]): Array<{ index: number; text: string }> {
   const result: Array<{ index: number; text: string }> = [];
   for (let i = 0; i < messages.length; i++) {
     const msg = messages[i];
-    if (msg.type === "user" && !isInternalMessage(msg.text)) {
+    if (msg.type === "user" && !isInternalMessage(msg.text) && !isSteeringMessage(msg)) {
       result.push({ index: i, text: msg.text });
     } else if (msg.type === "command") {
       result.push({ index: i, text: msg.name });
@@ -486,7 +402,13 @@ function TranscriptDetailComponent() {
                 onPermalink={setPermalinkedIndex}
               />
             ) : (
-              <CollapsedSteps key={`collapsed-${i}`} messages={segment.messages} showDebugInfo={showDebugInfo} />
+              <CollapsedSteps
+                key={`collapsed-${i}`}
+                items={segment.items}
+                stepCount={segment.stepCount}
+                steeringCount={segment.steeringCount}
+                showDebugInfo={showDebugInfo}
+              />
             ),
           )}
         </div>
@@ -1149,6 +1071,7 @@ function MessageBlock({ message, index, showDebugInfo, isPermalinked, onPermalin
     }
 
     const userImages = message.images ?? [];
+    const isSteeringMessage = message.variant === "steering";
 
     const handlePermalink = (e: React.MouseEvent) => {
       e.preventDefault();
@@ -1159,7 +1082,9 @@ function MessageBlock({ message, index, showDebugInfo, isPermalinked, onPermalin
     return (
       <div id={messageId} className="group/permalink scroll-mt-4">
         <div
-          className={`relative rounded-lg bg-secondary/80 px-5 py-5 ${isPermalinked ? "ring-1 ring-foreground/20" : ""}`}
+          className={`relative rounded-lg ${
+            isSteeringMessage ? "bg-muted/25 px-4 py-3" : "bg-secondary/80 px-5 py-5"
+          } ${isPermalinked ? "ring-1 ring-foreground/20" : ""}`}
         >
           <Button
             variant="ghost"
@@ -1171,7 +1096,10 @@ function MessageBlock({ message, index, showDebugInfo, isPermalinked, onPermalin
               <Link2 className="h-3.5 w-3.5" />
             </a>
           </Button>
-          <TruncatedUserMessage text={message.text} />
+          <TruncatedUserMessage
+            text={message.text}
+            className={isSteeringMessage ? "text-muted-foreground" : undefined}
+          />
           <ImageGallery images={userImages} />
         </div>
       </div>
@@ -1247,45 +1175,66 @@ function MessageBlock({ message, index, showDebugInfo, isPermalinked, onPermalin
 
 // Collapsed steps component - groups unimportant messages into a collapsible section
 function CollapsedSteps({
-  messages,
+  items,
+  stepCount,
+  steeringCount,
   showDebugInfo,
 }: {
-  messages: Array<{ message: UnifiedTranscriptMessage; index: number }>;
+  items: Array<
+    | { type: "steps"; messages: Array<{ message: UnifiedTranscriptMessage; index: number }> }
+    | { type: "steering"; message: UnifiedTranscriptMessage; index: number }
+  >;
+  stepCount: number;
+  steeringCount: number;
   showDebugInfo?: boolean;
 }) {
   const [isOpen, setIsOpen] = useState(false);
 
-  if (messages.length === 0) return null;
+  if (items.length === 0) return null;
 
   // Calculate total diff stats from Write/Edit tools in this collapsed section
   let totalAdded = 0;
   let totalRemoved = 0;
   let totalModified = 0;
 
-  for (const { message } of messages) {
-    if (message.type === "tool-call") {
-      const inputObj = message.input as Record<string, unknown> | undefined;
+  for (const item of items) {
+    if (item.type !== "steps") {
+      continue;
+    }
 
-      if (message.toolName === "Edit" && inputObj?.diff) {
-        const stats = parseDiffStats(String(inputObj.diff));
-        totalAdded += stats.added - stats.modified;
-        totalRemoved += stats.removed - stats.modified;
-        totalModified += stats.modified;
-      } else if (message.toolName === "Write" && inputObj?.content) {
-        const lineCount = String(inputObj.content).split("\n").length;
-        totalAdded += lineCount;
+    for (const { message } of item.messages) {
+      if (message.type === "tool-call") {
+        const inputObj = message.input as Record<string, unknown> | undefined;
+
+        if (message.toolName === "Edit" && inputObj?.diff) {
+          const stats = parseDiffStats(String(inputObj.diff));
+          totalAdded += stats.added - stats.modified;
+          totalRemoved += stats.removed - stats.modified;
+          totalModified += stats.modified;
+        } else if (message.toolName === "Write" && inputObj?.content) {
+          const lineCount = String(inputObj.content).split("\n").length;
+          totalAdded += lineCount;
+        }
       }
     }
   }
 
   const hasChanges = totalAdded > 0 || totalRemoved > 0 || totalModified > 0;
+  const hiddenSummaryParts: string[] = [];
+  if (stepCount > 0) {
+    hiddenSummaryParts.push(`${stepCount} step${stepCount === 1 ? "" : "s"}`);
+  }
+  if (steeringCount > 0) {
+    hiddenSummaryParts.push(`${steeringCount} steering message${steeringCount === 1 ? "" : "s"}`);
+  }
+  const hiddenSummary = hiddenSummaryParts.join(", ") || "steps";
 
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen} className="group/steps">
       <div className="flex items-center gap-2">
         <CollapsibleTrigger className="inline-flex items-center gap-2 rounded-md border border-border px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:border-muted-foreground/30 hover:text-foreground">
           <ChevronDown className="h-4 w-4 transition-transform group-data-[open]/steps:rotate-180" />
-          <span>{isOpen ? `Hide ${messages.length} steps` : `${messages.length} steps hidden`}</span>
+          <span>{isOpen ? `Hide ${hiddenSummary}` : `${hiddenSummary} hidden`}</span>
         </CollapsibleTrigger>
         {hasChanges && (
           <span className="flex items-center gap-1 text-sm">
@@ -1297,6 +1246,55 @@ function CollapsedSteps({
       </div>
       <CollapsibleContent>
         <div className="mt-3 ml-2 space-y-3 border-l border-border pl-4">
+          {items.map((item, itemIndex) => {
+            if (item.type === "steps") {
+              return (
+                <NestedCollapsedSteps
+                  key={`steps-${itemIndex}`}
+                  messages={item.messages}
+                  showDebugInfo={showDebugInfo}
+                />
+              );
+            }
+
+            return (
+              <MessageBlock
+                key={`steering-${item.index}`}
+                message={item.message}
+                index={item.index}
+                showDebugInfo={showDebugInfo}
+              />
+            );
+          })}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function NestedCollapsedSteps({
+  messages,
+  showDebugInfo,
+}: {
+  messages: Array<{ message: UnifiedTranscriptMessage; index: number }>;
+  showDebugInfo?: boolean;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  if (messages.length === 0) return null;
+
+  return (
+    <Collapsible open={isOpen} onOpenChange={setIsOpen} className="group/nested-steps">
+      <CollapsibleTrigger className="inline-flex items-center gap-2 rounded-md border border-border/70 px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:border-muted-foreground/30 hover:text-foreground">
+        <ChevronDown className="h-4 w-4 transition-transform group-data-[open]/nested-steps:rotate-180" />
+        <span>
+          {isOpen
+            ? `Hide ${messages.length} step${messages.length === 1 ? "" : "s"}`
+            : `${messages.length} step${messages.length === 1 ? "" : "s"} hidden`}
+        </span>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="mt-3 ml-2 space-y-3 border-l border-border/70 pl-4">
           {messages.map(({ message, index }) => (
             <MessageBlock key={index} message={message} index={index} showDebugInfo={showDebugInfo} />
           ))}
@@ -1306,19 +1304,21 @@ function CollapsedSteps({
   );
 }
 
-function TruncatedUserMessage({ text }: { text: string }) {
+function TruncatedUserMessage({ text, className }: { text: string; className?: string }) {
   const [isExpanded, setIsExpanded] = useState(false);
   // Rough heuristic: long content threshold
   const lineCount = text.split("\n").length;
   const isLong = text.length > 1600 || lineCount > 20;
 
   if (!isLong) {
-    return <p className="text-sm wrap-break-word whitespace-pre-wrap">{text}</p>;
+    return <p className={`text-sm wrap-break-word whitespace-pre-wrap ${className ?? ""}`}>{text}</p>;
   }
 
   return (
     <div>
-      <p className={`text-sm wrap-break-word whitespace-pre-wrap ${!isExpanded ? "line-clamp-[20]" : ""}`}>
+      <p
+        className={`text-sm wrap-break-word whitespace-pre-wrap ${className ?? ""} ${!isExpanded ? "line-clamp-[20]" : ""}`}
+      >
         {isExpanded ? text : text.trimEnd()}
       </p>
       <button

--- a/packages/server/src/routes/_app/app/logs.$id.tsx
+++ b/packages/server/src/routes/_app/app/logs.$id.tsx
@@ -62,14 +62,19 @@ import {
   PiIcon,
 } from "../../../components/icons/source-icons";
 import { MarkdownRenderer } from "../../../components/markdown-renderer";
-import { groupMessagesIntoSegments, isInternalMessage } from "../../../lib/message-segments";
+import {
+  groupMessagesIntoSegments,
+  isInternalMessage,
+  isSteeringMessage,
+  type CollapsedMessageSegmentItem,
+  type MessageReference,
+} from "../../../lib/message-segments";
 
 import {
   extractImageReferences,
   type ImageReference,
   replaceImageReferencesForDisplay,
 } from "../../../lib/message-utils";
-import { isSteeringMessage } from "../../../lib/message-segments";
 import { deleteTranscript, getTranscript, updateTitle, updateVisibility } from "../../../lib/server-functions";
 
 export const Route = createFileRoute("/_app/app/logs/$id")({
@@ -216,23 +221,11 @@ function TranscriptDetailComponent() {
   // Track permalinked message from URL hash
   const [permalinkedIndex, setPermalinkedIndex] = useState<number | null>(null);
 
-  // Auto-scroll to message and set permalink if hash is present in URL
+  // Restore the permalink first; its message scrolls into view after mounting.
   useEffect(() => {
-    const hash = window.location.hash;
-    if (hash) {
-      const target = document.querySelector(hash);
-      if (target) {
-        const rect = target.getBoundingClientRect();
-        const scrollTop = window.scrollY + rect.top - 16;
-        window.scrollTo({ top: scrollTop, behavior: "instant" });
-      }
-      // Set permalinked index from hash
-      const match = hash.match(/^#msg-(\d+)$/);
-      if (match) {
-        setPermalinkedIndex(parseInt(match[1], 10) - 1);
-      }
-    }
-  }, []);
+    const match = window.location.hash.match(/^#msg-(\d+)$/);
+    setPermalinkedIndex(match ? parseInt(match[1], 10) - 1 : null);
+  }, [data.id]);
 
   // Clear permalinked state on first user scroll (delay to ignore programmatic scrolls)
   useEffect(() => {
@@ -408,6 +401,8 @@ function TranscriptDetailComponent() {
                 stepCount={segment.stepCount}
                 steeringCount={segment.steeringCount}
                 showDebugInfo={showDebugInfo}
+                permalinkedIndex={permalinkedIndex}
+                onPermalink={setPermalinkedIndex}
               />
             ),
           )}
@@ -1063,6 +1058,12 @@ interface MessageBlockProps {
 function MessageBlock({ message, index, showDebugInfo, isPermalinked, onPermalink }: MessageBlockProps) {
   const messageId = `msg-${index + 1}`;
 
+  useEffect(() => {
+    if (isPermalinked) {
+      document.getElementById(messageId)?.scrollIntoView({ behavior: "instant", block: "start" });
+    }
+  }, [isPermalinked, messageId]);
+
   // User message - dark pill with avatar
   if (message.type === "user") {
     // Skip internal system messages
@@ -1179,16 +1180,26 @@ function CollapsedSteps({
   stepCount,
   steeringCount,
   showDebugInfo,
+  permalinkedIndex,
+  onPermalink,
 }: {
-  items: Array<
-    | { type: "steps"; messages: Array<{ message: UnifiedTranscriptMessage; index: number }> }
-    | { type: "steering"; message: UnifiedTranscriptMessage; index: number }
-  >;
+  items: CollapsedMessageSegmentItem[];
   stepCount: number;
   steeringCount: number;
   showDebugInfo?: boolean;
+  permalinkedIndex: number | null;
+  onPermalink: (index: number) => void;
 }) {
   const [isOpen, setIsOpen] = useState(false);
+  const containsPermalink = items.some((item) =>
+    item.type === "steering"
+      ? item.index === permalinkedIndex
+      : item.messages.some(({ index }) => index === permalinkedIndex),
+  );
+
+  useEffect(() => {
+    if (containsPermalink) setIsOpen(true);
+  }, [containsPermalink]);
 
   if (items.length === 0) return null;
 
@@ -1248,11 +1259,25 @@ function CollapsedSteps({
         <div className="mt-3 ml-2 space-y-3 border-l border-border pl-4">
           {items.map((item, itemIndex) => {
             if (item.type === "steps") {
+              if (steeringCount === 0) {
+                return item.messages.map(({ message, index }) => (
+                  <MessageBlock
+                    key={index}
+                    message={message}
+                    index={index}
+                    showDebugInfo={showDebugInfo}
+                    isPermalinked={permalinkedIndex === index}
+                    onPermalink={onPermalink}
+                  />
+                ));
+              }
               return (
                 <NestedCollapsedSteps
                   key={`steps-${itemIndex}`}
                   messages={item.messages}
                   showDebugInfo={showDebugInfo}
+                  permalinkedIndex={permalinkedIndex}
+                  onPermalink={onPermalink}
                 />
               );
             }
@@ -1263,6 +1288,8 @@ function CollapsedSteps({
                 message={item.message}
                 index={item.index}
                 showDebugInfo={showDebugInfo}
+                isPermalinked={permalinkedIndex === item.index}
+                onPermalink={onPermalink}
               />
             );
           })}
@@ -1275,11 +1302,20 @@ function CollapsedSteps({
 function NestedCollapsedSteps({
   messages,
   showDebugInfo,
+  permalinkedIndex,
+  onPermalink,
 }: {
-  messages: Array<{ message: UnifiedTranscriptMessage; index: number }>;
+  messages: MessageReference[];
   showDebugInfo?: boolean;
+  permalinkedIndex: number | null;
+  onPermalink: (index: number) => void;
 }) {
   const [isOpen, setIsOpen] = useState(false);
+  const containsPermalink = messages.some(({ index }) => index === permalinkedIndex);
+
+  useEffect(() => {
+    if (containsPermalink) setIsOpen(true);
+  }, [containsPermalink]);
 
   if (messages.length === 0) return null;
 
@@ -1296,7 +1332,14 @@ function NestedCollapsedSteps({
       <CollapsibleContent>
         <div className="mt-3 ml-2 space-y-3 border-l border-border/70 pl-4">
           {messages.map(({ message, index }) => (
-            <MessageBlock key={index} message={message} index={index} showDebugInfo={showDebugInfo} />
+            <MessageBlock
+              key={index}
+              message={message}
+              index={index}
+              showDebugInfo={showDebugInfo}
+              isPermalinked={permalinkedIndex === index}
+              onPermalink={onPermalink}
+            />
           ))}
         </div>
       </CollapsibleContent>

--- a/packages/shared/src/claudecode.test.ts
+++ b/packages/shared/src/claudecode.test.ts
@@ -1507,4 +1507,127 @@ describe("convertClaudeCodeTranscript", () => {
     const result = convertClaudeCodeTranscript(metaOnlyTranscript);
     expect(result).toBeNull();
   });
+
+  test("includes queued steering prompts as user messages", () => {
+    const transcript = [
+      {
+        parentUuid: null,
+        isSidechain: false,
+        cwd: "/Users/test/dev/project",
+        sessionId: "test-session",
+        version: "2.1.31",
+        gitBranch: "main",
+        type: "user",
+        message: {
+          role: "user",
+          content: "Deploy it",
+        },
+        uuid: "user-1",
+        timestamp: "2026-02-05T13:18:17.000Z",
+      },
+      {
+        parentUuid: "user-1",
+        isSidechain: false,
+        cwd: "/Users/test/dev/project",
+        sessionId: "test-session",
+        version: "2.1.31",
+        gitBranch: "main",
+        type: "assistant",
+        message: {
+          id: "assistant-1",
+          role: "assistant",
+          model: "claude-sonnet-4-5-20250929",
+          content: [
+            {
+              type: "tool_use",
+              id: "tool-1",
+              name: "Bash",
+              input: { command: "deploy" },
+            },
+          ],
+        },
+        uuid: "assistant-record-1",
+        timestamp: "2026-02-05T13:18:18.000Z",
+      },
+      {
+        parentUuid: "assistant-record-1",
+        isSidechain: false,
+        cwd: "/Users/test/dev/project",
+        sessionId: "test-session",
+        version: "2.1.31",
+        gitBranch: "main",
+        type: "user",
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "tool-1",
+              content: "done",
+              is_error: false,
+            },
+          ],
+        },
+        toolUseResult: {
+          stdout: "done",
+          stderr: "",
+          interrupted: false,
+          isImage: false,
+          noOutputExpected: false,
+        },
+        uuid: "tool-result-1",
+        timestamp: "2026-02-05T13:18:19.000Z",
+      },
+      {
+        parentUuid: "tool-result-1",
+        isSidechain: false,
+        cwd: "/Users/test/dev/project",
+        sessionId: "test-session",
+        version: "2.1.31",
+        gitBranch: "main",
+        type: "attachment",
+        attachment: {
+          type: "queued_command",
+          prompt: "if that's it, then redeploy, I rotated the secret and set the new one",
+          commandMode: "prompt",
+        },
+        uuid: "queued-command-1",
+        timestamp: "2026-02-05T13:18:19.001Z",
+      },
+      {
+        parentUuid: "queued-command-1",
+        isSidechain: false,
+        cwd: "/Users/test/dev/project",
+        sessionId: "test-session",
+        version: "2.1.31",
+        gitBranch: "main",
+        type: "assistant",
+        message: {
+          id: "assistant-2",
+          role: "assistant",
+          model: "claude-sonnet-4-5-20250929",
+          content: [
+            {
+              type: "text",
+              text: "Redeploying now.",
+            },
+          ],
+        },
+        uuid: "assistant-record-2",
+        timestamp: "2026-02-05T13:18:20.000Z",
+      },
+    ];
+
+    const result = convertClaudeCodeTranscript(transcript);
+    expect(result).not.toBeNull();
+    expect(result?.transcript.userMessageCount).toBe(2);
+    expect(result?.transcript.messages).toContainEqual(
+      expect.objectContaining({
+        type: "user",
+        id: "queued-command-1",
+        variant: "steering",
+        text: "if that's it, then redeploy, I rotated the secret and set the new one",
+      }),
+    );
+  });
 });

--- a/packages/shared/src/claudecode.ts
+++ b/packages/shared/src/claudecode.ts
@@ -1402,6 +1402,24 @@ function stripAnsiCodes(text: string): string {
   return text.replace(/\x1B\[[0-9;]*m/g, "");
 }
 
+function extractQueuedCommandPrompt(record: ClaudeMessageRecord): string | null {
+  if (record.type !== "attachment") {
+    return null;
+  }
+
+  const attachment = record.raw.attachment;
+  if (!attachment || typeof attachment !== "object") {
+    return null;
+  }
+
+  const attachmentRecord = attachment as Record<string, unknown>;
+  if (attachmentRecord.type !== "queued_command") {
+    return null;
+  }
+
+  return asNonEmptyString(attachmentRecord.prompt) ?? null;
+}
+
 type ConvertMessagesResult = {
   messages: UnifiedTranscriptMessage[];
   blobs: Map<string, TranscriptBlob>;
@@ -1440,6 +1458,45 @@ function convertTranscriptToMessages(transcript: ClaudeMessageRecord[]): Convert
   // Get cwd for path relativization
   const cwd = deriveWorkingDirectory(transcript);
 
+  const addUserMessage = (
+    id: string,
+    timestamp: string | undefined,
+    text: string,
+    images: Array<{ sha256: string; mediaType: string }> = [],
+    variant?: "steering",
+  ) => {
+    const dedupeKey = `${timestamp}:${text}`;
+    const existing = seenUserMessages.get(dedupeKey);
+
+    if (existing) {
+      if (!existing.hasImages && images.length > 0) {
+        const existingMsg = messages[existing.index] as Record<string, unknown>;
+        existingMsg.images = images;
+        existing.hasImages = true;
+      }
+      return;
+    }
+
+    const messageData: Record<string, unknown> = {
+      type: "user",
+      text,
+      id,
+      timestamp,
+    };
+
+    if (variant) {
+      messageData.variant = variant;
+    }
+
+    if (images.length > 0) {
+      messageData.images = images;
+    }
+
+    const msgIndex = messages.length;
+    messages.push(unifiedTranscriptMessageSchema.parse(messageData));
+    seenUserMessages.set(dedupeKey, { index: msgIndex, hasImages: images.length > 0 });
+  };
+
   for (const record of transcript) {
     if (record.isMeta) {
       continue;
@@ -1447,6 +1504,14 @@ function convertTranscriptToMessages(transcript: ClaudeMessageRecord[]): Convert
 
     const metadata = buildMessageMetadata(record);
     const type = record.type;
+
+    if (type === "attachment") {
+      const queuedPrompt = extractQueuedCommandPrompt(record);
+      if (queuedPrompt) {
+        addUserMessage(record.uuid, metadata.timestamp, queuedPrompt, [], "steering");
+      }
+      continue;
+    }
 
     if (type === "user") {
       const { texts, images, toolResults } = extractUserContent(record, blobs);
@@ -1521,38 +1586,8 @@ function convertTranscriptToMessages(transcript: ClaudeMessageRecord[]): Convert
 
         const messageType = record.isCompactSummary ? "compaction-summary" : "user";
 
-        // Deduplicate user messages with same timestamp and text
-        // Claude Code sometimes logs the same message twice (once with images, once without)
         if (messageType === "user") {
-          const dedupeKey = `${metadata.timestamp}:${cleanedText}`;
-          const existing = seenUserMessages.get(dedupeKey);
-
-          if (existing) {
-            // If this version has images and the existing one doesn't, update it
-            if (!existing.hasImages && images.length > 0) {
-              const existingMsg = messages[existing.index] as Record<string, unknown>;
-              existingMsg.images = images;
-              existing.hasImages = true;
-            }
-            // Skip adding duplicate
-            continue;
-          }
-
-          const messageData: Record<string, unknown> = {
-            type: messageType,
-            text: cleanedText,
-            id: record.uuid,
-            timestamp: metadata.timestamp,
-          };
-
-          // Attach images to this user message
-          if (images.length > 0) {
-            messageData.images = images;
-          }
-
-          const msgIndex = messages.length;
-          messages.push(unifiedTranscriptMessageSchema.parse(messageData));
-          seenUserMessages.set(dedupeKey, { index: msgIndex, hasImages: images.length > 0 });
+          addUserMessage(record.uuid, metadata.timestamp, cleanedText, images);
         } else {
           // Non-user message (compaction-summary)
           const messageData: Record<string, unknown> = {

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -10,6 +10,7 @@ const imageReferenceSchema = z.object({
 const userMessageSchema = z.object({
   type: z.literal("user"),
   text: z.string(),
+  variant: z.enum(["steering"]).optional(),
   images: z.array(imageReferenceSchema).optional(),
   id: z.string().optional(),
   timestamp: z.string().optional(),


### PR DESCRIPTION
## Summary
- surface Claude Code queued steering prompts in unified transcripts
- render steering prompts less prominently and exclude them from the prompts sidebar
- add two-level collapsed transcript groups so steering prompts appear between hidden operational step groups


<img width="1868" height="524" alt="CleanShot 2026-04-15 at 01 06 45@2x" src="https://github.com/user-attachments/assets/7b8f1dab-861a-4871-b1fa-428e016b2746" />

->

<img width="1856" height="956" alt="CleanShot 2026-04-15 at 01 06 33@2x" src="https://github.com/user-attachments/assets/becfdba5-7b99-475c-ab18-bfbaf0c01227" />

