### PR TITLE
cli: Use cross-spawn for Windows .cmd shim resolution

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,7 @@
         "agentlogs": "dist/index.js",
       },
       "dependencies": {
+        "cross-spawn": "^7.0.6",
         "jsonc-parser": "^3.3.1",
         "libsql": "^0.5.22",
       },
@@ -28,6 +29,7 @@
         "@agentlogs/shared": "workspace:*",
         "@mariozechner/pi-tui": "^0.57.1",
         "@paralleldrive/cuid2": "^3.3.0",
+        "@types/cross-spawn": "^6.0.6",
         "aywson": "^0.0.16",
         "better-auth": "^1.5.4",
         "chalk": "^5.6.2",
@@ -812,6 +814,8 @@
     "@types/better-sqlite3": ["@types/better-sqlite3@7.6.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA=="],
 
     "@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
+
+    "@types/cross-spawn": ["@types/cross-spawn@6.0.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA=="],
 
     "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,6 +39,7 @@
     "check": "tsgo --project tsconfig.json"
   },
   "dependencies": {
+    "cross-spawn": "^7.0.6",
     "jsonc-parser": "^3.3.1",
     "libsql": "^0.5.22"
   },
@@ -46,6 +47,7 @@
     "@agentlogs/shared": "workspace:*",
     "@mariozechner/pi-tui": "^0.57.1",
     "@paralleldrive/cuid2": "^3.3.0",
+    "@types/cross-spawn": "^6.0.6",
     "aywson": "^0.0.16",
     "better-auth": "^1.5.4",
     "chalk": "^5.6.2",

--- a/packages/cli/src/commands/opencode/hook.ts
+++ b/packages/cli/src/commands/opencode/hook.ts
@@ -6,8 +6,8 @@
  */
 
 import { readFileSync, unlinkSync, openSync, closeSync } from "fs";
-import { spawn } from "child_process";
 import * as os from "os";
+import spawn from "cross-spawn";
 import type { OpenCodeExport } from "@agentlogs/shared";
 import { convertOpenCodeTranscript } from "@agentlogs/shared/opencode";
 import { LiteLLMPricingFetcher } from "@agentlogs/shared/pricing";

--- a/packages/cli/src/commands/opencode/upload.ts
+++ b/packages/cli/src/commands/opencode/upload.ts
@@ -1,6 +1,6 @@
-import { spawn } from "child_process";
 import { readFileSync, unlinkSync, openSync, closeSync } from "fs";
 import * as os from "os";
+import spawn from "cross-spawn";
 import type { OpenCodeExport } from "@agentlogs/shared";
 import { convertOpenCodeTranscript } from "@agentlogs/shared/opencode";
 import { LiteLLMPricingFetcher } from "@agentlogs/shared/pricing";

--- a/packages/cli/src/commands/upload.ts
+++ b/packages/cli/src/commands/upload.ts
@@ -1,5 +1,5 @@
 import { resolve } from "path";
-import { spawnSync } from "child_process";
+import { sync as spawnSync } from "cross-spawn";
 import { existsSync, readFileSync } from "fs";
 import { discoverAllTranscripts, type DiscoveredTranscript, type TranscriptSource } from "@agentlogs/shared";
 import { convertOpenCodeTranscript, type OpenCodeExport } from "@agentlogs/shared/opencode";


### PR DESCRIPTION
Replace child_process spawn/spawnSync with cross-spawn in opencode hook, upload, and general upload commands. On Windows, Node's spawn cannot resolve .cmd/.ps1 shims (like the opencode npm package), causing ENOENT errors. cross-spawn handles this transparently across all platforms without requiring shell: true.