### PR TITLE
Fix team dashboard reactivity and make landing CTAs auth-aware

### DIFF
--- a/packages/server/src/routes/_app/app/team/index.tsx
+++ b/packages/server/src/routes/_app/app/team/index.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, useRouter } from "@tanstack/react-router";
+import { createFileRoute, useRouter, useRouterState } from "@tanstack/react-router";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -46,8 +46,18 @@ const PERIOD_OPTIONS: { value: PeriodDays; label: string }[] = [
   { value: 365, label: "1 Year" },
 ];
 
+const DEFAULT_PERIOD_DAYS: PeriodDays = 30;
+
 export const Route = createFileRoute("/_app/app/team/")({
-  loader: () => getTeamDashboardData({ data: { days: 30 } }),
+  // `days` lives in the URL so the loader owns the time window. It's optional for
+  // navigation (links to this page need not specify it); the default is applied where
+  // it's read. Invalid/out-of-range values fall back to the default.
+  validateSearch: (search: Record<string, unknown>): { days?: PeriodDays } => {
+    const raw = Number(search.days);
+    return PERIOD_OPTIONS.some((opt) => opt.value === raw) ? { days: raw as PeriodDays } : {};
+  },
+  loaderDeps: ({ search }) => ({ days: search.days ?? DEFAULT_PERIOD_DAYS }),
+  loader: ({ deps: { days } }) => getTeamDashboardData({ data: { days } }),
   component: TeamDashboardPage,
 });
 
@@ -124,36 +134,24 @@ function getAgentIcon(agent: string | null) {
 }
 
 function TeamDashboardPage() {
-  const initialData = Route.useLoaderData();
+  const data = Route.useLoaderData();
+  const { days = DEFAULT_PERIOD_DAYS } = Route.useSearch();
   const router = useRouter();
-  const [days, setDays] = useState<PeriodDays>(30);
-  const [data, setData] = useState(initialData);
-  const [isLoading, setIsLoading] = useState(false);
+  const navigate = Route.useNavigate();
+  // Dim the page while the route loader is (re)fetching — e.g. on a period change.
+  const isLoading = useRouterState({ select: (s) => s.isLoading });
   const [isDeleting, setIsDeleting] = useState(false);
   const [isLeaving, setIsLeaving] = useState(false);
 
   const { team, stats, memberStats, activity, userNames, isHourly, modelUsage, agentUsage, session } = data;
 
-  const refresh = async () => {
-    setIsLoading(true);
-    try {
-      const newData = await getTeamDashboardData({ data: { days } });
-      setData(newData);
-    } finally {
-      setIsLoading(false);
-    }
-  };
+  // Re-run the route loader so the page reflects the latest server data.
+  const refresh = () => router.invalidate();
 
-  const handlePeriodChange = async (newDays: string) => {
-    const d = Number(newDays) as PeriodDays;
-    setDays(d);
-    setIsLoading(true);
-    try {
-      const newData = await getTeamDashboardData({ data: { days: d } });
-      setData(newData);
-    } finally {
-      setIsLoading(false);
-    }
+  // The period lives in the URL (?days=); navigating re-runs the loader, and the
+  // fresh data flows back through useLoaderData — one source of truth for the page.
+  const handlePeriodChange = (newDays: string) => {
+    navigate({ search: { days: Number(newDays) as PeriodDays }, replace: true });
   };
 
   const handleDeleteTeam = async () => {

--- a/packages/server/src/routes/index.tsx
+++ b/packages/server/src/routes/index.tsx
@@ -64,6 +64,9 @@ const faqs = [
 ];
 
 function LandingPage() {
+  // Session is fetched once in the root route's beforeLoad and shared via context.
+  const { session } = Route.useRouteContext();
+
   return (
     <div className="bg-background text-foreground">
       {/* Nav */}
@@ -86,10 +89,10 @@ function LandingPage() {
               GitHub
             </a>
             <a
-              href="/auth/login"
+              href={session ? "/app" : "/auth/login"}
               className="rounded-md bg-primary px-3 py-1.5 text-primary-foreground hover:bg-primary/90"
             >
-              Log in
+              {session ? "Go to app" : "Log in"}
             </a>
           </div>
         </div>
@@ -164,10 +167,10 @@ function LandingPage() {
           </p>
           <div className="mt-8 flex gap-3">
             <a
-              href="/auth/login"
+              href={session ? "/app" : "/auth/login"}
               className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
             >
-              Join the cloud waitlist
+              {session ? "Go to app" : "Join the cloud waitlist"}
             </a>
             <a
               href="https://github.com/agentlogs/agentlogs"


### PR DESCRIPTION
Two small UI fixes to the web app, one commit each.

## 1. Team dashboard did not update after create or delete

Creating or deleting a team did not update the dashboard. You had to reload to see the change. Because the first click gave no feedback, it was easy to click Create again and hit an "Already in team" error from the second request.

Root cause: the page copied its loader data into local state and rendered from the copy.

```tsx
const initialData = Route.useLoaderData();
const [data, setData] = useState(initialData);
```

`useState` only uses its argument on the first render, so the copy never saw fresh data. Create and delete called `router.invalidate()`, which re-runs the loader, but the component kept reading the stale local copy. The period dropdown worked only because it wrote to that copy directly with `setData`.

Fix: render from live loader data (`Route.useLoaderData()`), and move the period filter into the URL (`?days=`) so the loader owns it. After this, `router.invalidate()` updates the page for create, delete, leave, add member, and remove member, with no per-handler wiring. The default period (30) was duplicated in three places and is now one constant.

I also considered a smaller fix: point create and delete at the existing refresh helper that calls `setData`. I did not take it because it keeps two sources of truth, which is what caused the bug in the first place. The loader-driven version removes that split. A side benefit is that the period now lives in the URL, so it is shareable and survives a reload.

## 2. Landing page showed "Log in" when already signed in

The landing navbar always showed "Log in", even for signed-in users. The route never read auth state, even though the session is already available in route context from the root route.

Fix: read the session in the landing route and show "Go to app" (pointing at `/app`) when signed in, for both the navbar and the hero button. Logged out is unchanged.

One decision worth noting: waitlist users have a session but cannot enter `/app`. I show "Go to app" for any signed-in user and let the existing `_app` guard send waitlisted users to `/waitlist`. This keeps the landing code simple and avoids a broken state, since they land on the existing "You're on the waitlist" page.
