### PR TITLE
Make team dashboard UI refresh on create/delete, and make landing CTAs auth-aware

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -3,6 +3,14 @@ title: "Changelog"
 description: "Product updates and announcements"
 ---
 
+<Update label="September 8, 2026">
+## Team Dashboard and Landing Page Fixes
+
+- Team changes now refresh the dashboard immediately, with controls staying busy until the update completes; the selected period persists in the URL (#42) thanks @souritrakar
+- Signed-in users now see "Go to app" in the landing page navigation and hero
+- Removing members, leaving a team, and deleting a team now use in-app confirmation dialogs
+</Update>
+
 <Update label="April 18, 2026">
 ## OpenAI-Compatible Summary Backends
 

--- a/packages/server/src/routes/_app/app/team/index.tsx
+++ b/packages/server/src/routes/_app/app/team/index.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, useRouter } from "@tanstack/react-router";
+import { createFileRoute, useRouter, useRouterState } from "@tanstack/react-router";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -46,8 +46,16 @@ const PERIOD_OPTIONS: { value: PeriodDays; label: string }[] = [
   { value: 365, label: "1 Year" },
 ];
 
+const DEFAULT_PERIOD_DAYS: PeriodDays = 30;
+
 export const Route = createFileRoute("/_app/app/team/")({
-  loader: () => getTeamDashboardData({ data: { days: 30 } }),
+  // Optional ?days= filter; unknown or missing values fall back to the default.
+  validateSearch: (search: Record<string, unknown>): { days?: PeriodDays } => {
+    const raw = Number(search.days);
+    return PERIOD_OPTIONS.some((opt) => opt.value === raw) ? { days: raw as PeriodDays } : {};
+  },
+  loaderDeps: ({ search }) => ({ days: search.days ?? DEFAULT_PERIOD_DAYS }),
+  loader: ({ deps: { days } }) => getTeamDashboardData({ data: { days } }),
   component: TeamDashboardPage,
 });
 
@@ -124,36 +132,23 @@ function getAgentIcon(agent: string | null) {
 }
 
 function TeamDashboardPage() {
-  const initialData = Route.useLoaderData();
+  const data = Route.useLoaderData();
+  const { days = DEFAULT_PERIOD_DAYS } = Route.useSearch();
   const router = useRouter();
-  const [days, setDays] = useState<PeriodDays>(30);
-  const [data, setData] = useState(initialData);
-  const [isLoading, setIsLoading] = useState(false);
+  const navigate = Route.useNavigate();
+  // Dim the page while the loader refetches (e.g. a period change).
+  const isLoading = useRouterState({ select: (s) => s.isLoading });
   const [isDeleting, setIsDeleting] = useState(false);
   const [isLeaving, setIsLeaving] = useState(false);
 
   const { team, stats, memberStats, activity, userNames, isHourly, modelUsage, agentUsage, session } = data;
 
-  const refresh = async () => {
-    setIsLoading(true);
-    try {
-      const newData = await getTeamDashboardData({ data: { days } });
-      setData(newData);
-    } finally {
-      setIsLoading(false);
-    }
-  };
+  // Re-run the loader to refresh after a mutation.
+  const refresh = () => router.invalidate();
 
-  const handlePeriodChange = async (newDays: string) => {
-    const d = Number(newDays) as PeriodDays;
-    setDays(d);
-    setIsLoading(true);
-    try {
-      const newData = await getTeamDashboardData({ data: { days: d } });
-      setData(newData);
-    } finally {
-      setIsLoading(false);
-    }
+  // Period lives in the URL; navigating re-runs the loader.
+  const handlePeriodChange = (newDays: string) => {
+    navigate({ search: { days: Number(newDays) as PeriodDays }, replace: true });
   };
 
   const handleDeleteTeam = async () => {

--- a/packages/server/src/routes/_app/app/team/index.tsx
+++ b/packages/server/src/routes/_app/app/team/index.tsx
@@ -1,5 +1,16 @@
 import { createFileRoute, useRouter, useRouterState } from "@tanstack/react-router";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
@@ -138,43 +149,41 @@ function TeamDashboardPage() {
   const navigate = Route.useNavigate();
   // Dim the page while the loader refetches (e.g. a period change).
   const isLoading = useRouterState({ select: (s) => s.isLoading });
-  const [isDeleting, setIsDeleting] = useState(false);
-  const [isLeaving, setIsLeaving] = useState(false);
+  const [teamAction, setTeamAction] = useState<"delete" | "leave" | null>(null);
+  const [isTeamActionPending, setIsTeamActionPending] = useState(false);
+  const [teamActionError, setTeamActionError] = useState<string | null>(null);
 
   const { team, stats, memberStats, activity, userNames, isHourly, modelUsage, agentUsage, session } = data;
 
-  // Re-run the loader to refresh after a mutation.
-  const refresh = () => router.invalidate();
+  // Keep mutations pending until the refreshed loader data is ready.
+  const refresh = () => router.invalidate({ sync: true });
 
   // Period lives in the URL; navigating re-runs the loader.
   const handlePeriodChange = (newDays: string) => {
     navigate({ search: { days: Number(newDays) as PeriodDays }, replace: true });
   };
 
-  const handleDeleteTeam = async () => {
-    if (!team || !confirm("Are you sure you want to delete this team? All members will be removed.")) return;
-    setIsDeleting(true);
+  const handleTeamAction = async () => {
+    if (!team || !teamAction) return;
+    setIsTeamActionPending(true);
+    setTeamActionError(null);
     try {
-      await deleteTeam({ data: team.id });
-      router.invalidate();
+      if (teamAction === "delete") {
+        await deleteTeam({ data: team.id });
+      } else {
+        await leaveTeam({ data: team.id });
+      }
+      await refresh();
+      setTeamAction(null);
+    } catch (err) {
+      setTeamActionError(err instanceof Error ? err.message : `Failed to ${teamAction} team`);
     } finally {
-      setIsDeleting(false);
-    }
-  };
-
-  const handleLeaveTeam = async () => {
-    if (!team || !confirm("Are you sure you want to leave this team?")) return;
-    setIsLeaving(true);
-    try {
-      await leaveTeam({ data: team.id });
-      router.invalidate();
-    } finally {
-      setIsLeaving(false);
+      setIsTeamActionPending(false);
     }
   };
 
   if (!team) {
-    return <NoTeamView onSuccess={() => router.invalidate()} />;
+    return <NoTeamView onSuccess={refresh} />;
   }
 
   const isOwner = session?.user?.id === team.ownerId;
@@ -209,6 +218,43 @@ function TeamDashboardPage() {
 
   return (
     <div className={`space-y-8 ${isLoading ? "opacity-60" : ""}`}>
+      <AlertDialog
+        open={teamAction !== null}
+        onOpenChange={(open) => {
+          if (!open && !isTeamActionPending) {
+            setTeamAction(null);
+            setTeamActionError(null);
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{teamAction === "delete" ? "Delete team?" : "Leave team?"}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {teamAction === "delete"
+                ? `This will permanently delete ${team.name} and remove all its members.`
+                : `You will lose access to ${team.name}'s shared transcripts and dashboard.`}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          {teamActionError && (
+            <p role="alert" className="text-sm text-destructive">
+              {teamActionError}
+            </p>
+          )}
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isTeamActionPending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction variant="destructive" onClick={handleTeamAction} disabled={isTeamActionPending}>
+              {isTeamActionPending
+                ? teamAction === "delete"
+                  ? "Deleting..."
+                  : "Leaving..."
+                : teamAction === "delete"
+                  ? "Delete team"
+                  : "Leave team"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
@@ -232,24 +278,24 @@ function TeamDashboardPage() {
           </Select>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon" className="h-8 w-8">
+              <Button variant="ghost" size="icon" className="h-8 w-8" aria-label="Team actions">
                 <MoreHorizontal className="h-4 w-4" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               {isOwner ? (
                 <DropdownMenuItem
-                  onClick={handleDeleteTeam}
-                  disabled={isDeleting}
+                  onClick={() => setTeamAction("delete")}
+                  disabled={isTeamActionPending}
                   className="whitespace-nowrap text-destructive focus:text-destructive"
                 >
                   <Trash2 className="h-4 w-4" />
-                  {isDeleting ? "Deleting..." : "Delete Team"}
+                  Delete Team
                 </DropdownMenuItem>
               ) : (
-                <DropdownMenuItem onClick={handleLeaveTeam} disabled={isLeaving}>
+                <DropdownMenuItem onClick={() => setTeamAction("leave")} disabled={isTeamActionPending}>
                   <UserMinus className="h-4 w-4" />
-                  {isLeaving ? "Leaving..." : "Leave Team"}
+                  Leave Team
                 </DropdownMenuItem>
               )}
             </DropdownMenuContent>
@@ -529,35 +575,67 @@ function RemoveMemberButton({
   teamId: string;
   userId: string;
   userName: string;
-  onRemoved: () => void;
+  onRemoved: () => Promise<void>;
 }) {
   const [isRemoving, setIsRemoving] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const handleRemove = async () => {
-    if (!confirm(`Remove ${userName} from the team?`)) return;
     setIsRemoving(true);
+    setError(null);
     try {
       await removeMember({ data: { teamId, targetUserId: userId } });
-      onRemoved();
+      await onRemoved();
+      setIsOpen(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to remove member");
     } finally {
       setIsRemoving(false);
     }
   };
 
   return (
-    <Button
-      variant="ghost"
-      size="sm"
-      className="h-7 text-xs text-muted-foreground hover:text-destructive"
-      onClick={handleRemove}
-      disabled={isRemoving}
+    <AlertDialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!isRemoving) {
+          setIsOpen(open);
+          setError(null);
+        }
+      }}
     >
-      {isRemoving ? "..." : "Remove"}
-    </Button>
+      <AlertDialogTrigger
+        render={
+          <Button variant="ghost" size="sm" className="h-7 text-xs text-muted-foreground hover:text-destructive" />
+        }
+      >
+        Remove
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Remove member?</AlertDialogTitle>
+          <AlertDialogDescription>
+            {userName || "This member"} will lose access to the team's shared transcripts and dashboard.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        {error && (
+          <p role="alert" className="text-sm text-destructive">
+            {error}
+          </p>
+        )}
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isRemoving}>Cancel</AlertDialogCancel>
+          <AlertDialogAction variant="destructive" onClick={handleRemove} disabled={isRemoving}>
+            {isRemoving ? "Removing..." : "Remove member"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }
 
-function AddMemberPopover({ teamId, onSuccess }: { teamId: string; onSuccess: () => void }) {
+function AddMemberPopover({ teamId, onSuccess }: { teamId: string; onSuccess: () => Promise<void> }) {
   const [isOpen, setIsOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<"email" | "link">("email");
   const [email, setEmail] = useState("");
@@ -574,8 +652,8 @@ function AddMemberPopover({ teamId, onSuccess }: { teamId: string; onSuccess: ()
     setEmailError(null);
     try {
       await addMemberByEmail({ data: { teamId, email } });
+      await onSuccess();
       setEmail("");
-      onSuccess();
       setIsOpen(false);
     } catch (err) {
       setEmailError(err instanceof Error ? err.message : "Failed to add member");
@@ -686,7 +764,7 @@ function AddMemberPopover({ teamId, onSuccess }: { teamId: string; onSuccess: ()
   );
 }
 
-function NoTeamView({ onSuccess }: { onSuccess: () => void }) {
+function NoTeamView({ onSuccess }: { onSuccess: () => Promise<void> }) {
   const [teamName, setTeamName] = useState("");
   const [isCreating, setIsCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -698,7 +776,7 @@ function NoTeamView({ onSuccess }: { onSuccess: () => void }) {
     setError(null);
     try {
       await createTeam({ data: { name: teamName } });
-      onSuccess();
+      await onSuccess();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to create team");
     } finally {

--- a/packages/server/src/routes/index.tsx
+++ b/packages/server/src/routes/index.tsx
@@ -64,6 +64,9 @@ const faqs = [
 ];
 
 function LandingPage() {
+  // Session is fetched once in the root route's beforeLoad and shared via context.
+  const { session } = Route.useRouteContext();
+
   return (
     <div className="bg-background text-foreground">
       {/* Nav */}
@@ -86,10 +89,10 @@ function LandingPage() {
               GitHub
             </a>
             <a
-              href="/auth/login"
+              href={session ? "/app" : "/auth/login"}
               className="rounded-md bg-primary px-3 py-1.5 text-primary-foreground hover:bg-primary/90"
             >
-              Log in
+              {session ? "Go to app" : "Log in"}
             </a>
           </div>
         </div>
@@ -164,10 +167,10 @@ function LandingPage() {
           </p>
           <div className="mt-8 flex gap-3">
             <a
-              href="/auth/login"
+              href={session ? "/app" : "/auth/login"}
               className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
             >
-              Join the cloud waitlist
+              {session ? "Go to app" : "Join the cloud waitlist"}
             </a>
             <a
               href="https://github.com/agentlogs/agentlogs"


### PR DESCRIPTION
**I'm quite excited to start contributing to this repo, this is my first PR!** As part of maintaining a clean documentation process to ensure proper collaboration and oversight on AI (to avoid blindly generating code), **I am maintaining docs for each issue in a PR.** Each doc is generated and updated initially with AI acting on my instructions, including programmatically generated snapshots during web-app testing with Playwright. **I review it at the end and polish it before including it here, more details in the doc.**

**Issue 1: [https://app.notion.com/p/I1-Team-dashboard-not-updating-after-create-or-delete-380deaebbf24812093a8da9037bff72c?source=copy_link](url)**

**Issue 2: [https://app.notion.com/p/I2-Landing-page-showed-Log-in-when-already-signed-in-380deaebbf2481f5a106efff9ef0ab20?source=copy_link](url)**

### 1. Team dashboard page UI did not update instantly/refresh after create or delete Team

Creating or deleting a team did not update the dashboard. You had to reload to see
the change. Because the first click gave no feedback, it was possible to click Create
again and hit an "Already in team" error from the second request.

Why this problem occured: the page copied its loader data into local state and rendered from the copy.

    const initialData = Route.useLoaderData();
    const [data, setData] = useState(initialData);

`useState` only uses its argument on the first render, so the copy never saw fresh data. Create and delete called `router.invalidate()`, which re-runs the loader, but the component kept reading the stale local copy. The period dropdown worked only because it wrote to that copy directly with `setData`.

Fix implemented: render from live loader data (`Route.useLoaderData()`), and move the period filter into the URL (`?days=`). After this, `router.invalidate()` updates the page for create, delete, leave, add member, and remove member. The default period (30) was duplicated in three places and is now one constant parameter.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/80cb2d26-41ba-46fd-8e51-c1798199976d" />

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/926e2229-ade1-4b4a-abad-bf838b923f60" />

The period variable is now a parameter in the URL, so it triggers a loader reload when a new period is selected, and the UI updates automatically. It is now a single shared source of truth (the loader) rather than calling the server function separately and updating the state locally.


### 2. Landing page showed "Log in" when already signed in

The landing navbar always showed "Log in", even for signed-in users. The route never read auth state, even though the session is already available in route context from the root route.

<img width="804" height="122" alt="image" src="https://github.com/user-attachments/assets/40f83012-93aa-4438-9ded-29bd0f88e2dc" />


**Fix**: read the session in the landing route and show "Go to app" (pointing at `/app`) when signed in, for both the navbar and the hero button.

Waitlist users have a session but cannot enter `/app`. I show "Go to app" for any signed-in user and let the existing `_app` guard send waitlisted users to `/waitlist`, where they see the existing "You're on the waitlist" page. This keeps the landing code simple and avoids a broken state.

<img width="804" height="122" alt="image" src="https://github.com/user-attachments/assets/932fee4e-d30f-46de-8076-57abd21311f7" />


## Testing (manual UI testing myself and AI-testing and status report generated by Claude Code)

- `bun run check` (typecheck, lint, format) passes.
- Unit tests pass (127).
- Verified both fixes with Playwright. Team create renders the dashboard with no
  reload, and period changes update the URL and survive a reload. Landing CTAs are
  correct for logged-out, signed-in, and waitlist states.
