### PR TITLE
Attribute uploads to the best allowlisted repo across a session's directories

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -3,6 +3,14 @@ title: "Changelog"
 description: "Product updates and announcements"
 ---
 
+<Update label="September 9, 2026">
+## Repository Attribution Across Session Directories
+
+- Claude Code and Codex uploads now select the most active allowed repository across recorded directories and remotes, including fork upstreams and linked Git worktrees (#43) thanks @jdrhyne
+- Capture checks cover every discovered Git root, with clear explanations when a denied, unlisted, or unresolved root blocks an upload
+- Sync uses the selected repository for filtering and change detection
+</Update>
+
 <Update label="September 8, 2026">
 ## Steering Messages
 

--- a/docs/cli/configuration.mdx
+++ b/docs/cli/configuration.mdx
@@ -52,3 +52,17 @@ Repository permissions are configured in `settings.json`:
 | `repos[key].allow`                     | boolean                               | Whether to capture this repo                  |
 | `repos[key].visibility`                | `"private"` \| `"team"` \| `"public"` | Visibility override                           |
 | `repos[key].addTranscriptLinkToCommit` | boolean                               | Per-repo override for adding transcript links |
+
+## Sessions with Multiple Directories
+
+For Claude Code and Codex JSONL uploads, capture permissions are checked across the session's recorded working directories before upload:
+
+- In **allowlist** mode, every discovered Git root must have at least one allowlisted remote. A root with no remote, an unreadable config, or an unsupported remote URL blocks the whole upload.
+- In **denylist** mode, any explicitly denied remote blocks the whole upload, including when another remote or directory is allowed.
+- Directories outside Git repositories do not add another Git root to check. A session that starts in your home directory and then works in an allowed clone can upload. If no repository is found anywhere, allowlist mode skips it and denylist mode permits it.
+
+When capture is permitted, AgentLogs attributes the transcript to the Git root with the most directory references in the transcript, combining references to its subdirectories. Ties keep the first encountered candidate. Within that root, `origin` is preferred when allowed; otherwise another allowed remote, such as `upstream`, is used. The selected repository also supplies the visibility setting and repository links.
+
+For a fork with a personal `origin` and an allowlisted `upstream`, add the upstream's normalized repository identifier to `repos`, for example `github.com/myorg/project`. Use `agentlogs settings` to edit these entries. `agentlogs allow` still applies to the current clone's `origin`; Claude Code's commit-link permission check also uses that origin.
+
+Linked Git worktrees use their shared repository config and their own branch. Directory discovery reads Claude Code's record-level `cwd` and Codex's `session_meta` and `turn_context` payloads. Discovery and hook directory hints supplement these recorded directories for permission checks. AgentLogs does not infer directory changes from shell commands or message text.

--- a/fixtures/repo-resolution/fork-upstream.jsonl
+++ b/fixtures/repo-resolution/fork-upstream.jsonl
@@ -1,0 +1,3 @@
+{"type":"user","cwd":"/Users/me/Projects/repo-fork","gitBranch":"feature/y","content":"work in my fork"}
+{"type":"assistant","cwd":"/Users/me/Projects/repo-fork","content":"editing files"}
+{"type":"assistant","cwd":"/Users/me/Projects/repo-fork","content":"opening a PR to upstream"}

--- a/fixtures/repo-resolution/home-then-clone.jsonl
+++ b/fixtures/repo-resolution/home-then-clone.jsonl
@@ -1,0 +1,6 @@
+{"type":"user","cwd":"/Users/me","gitBranch":"main","content":"kick off work from home"}
+{"type":"assistant","cwd":"/Users/me","content":"cd into the clone"}
+{"type":"user","cwd":"/Users/me/Projects/repo","gitBranch":"feature/x","content":"work here"}
+{"type":"assistant","cwd":"/Users/me/Projects/repo","content":"editing files"}
+{"type":"assistant","cwd":"/Users/me/Projects/repo","content":"running tests"}
+{"type":"assistant","cwd":"/Users/me/Projects/repo","content":"pushing branch"}

--- a/packages/cli/src/commands/claudecode/sync.ts
+++ b/packages/cli/src/commands/claudecode/sync.ts
@@ -2,11 +2,19 @@ import { createHash } from "crypto";
 import { promises as fs } from "fs";
 import { homedir } from "os";
 import { basename, extname, join, relative, resolve } from "path";
-import { fetchTranscriptMetadata, getRepoMetadata } from "@agentlogs/shared";
+import { fetchTranscriptMetadata } from "@agentlogs/shared";
 import { convertClaudeCodeTranscript, resolveGitContext } from "@agentlogs/shared/claudecode";
 import { LiteLLMPricingFetcher } from "@agentlogs/shared/pricing";
 import { getAuthenticatedEnvironments, type Environment } from "../../config";
-import { performUpload, prepareUnifiedTranscriptForUpload } from "../../lib/perform-upload";
+import {
+  extractCwdCandidatesFromRecords,
+  extractGitBranchFromRecords,
+  performUpload,
+  prepareUnifiedTranscriptForUpload,
+  skipMessageLines,
+  stampResolvedRepoId,
+} from "../../lib/perform-upload";
+import { resolveUploadTarget } from "../../lib/repo-resolution";
 
 interface LocalTranscriptInfo {
   transcriptId: string;
@@ -194,12 +202,23 @@ async function discoverLocalTranscripts(projectsRoot: string): Promise<LocalTran
 
       try {
         const raw = await fs.readFile(filePath, "utf8");
-        const cwd = extractCwdFromTranscript(raw);
-        const repoId = await resolveRepoIdFromCwd(cwd);
-
-        // Parse records and convert to unified format for sha256 computation
+        // Use the same permission and attribution rules as the upload, so repo
+        // filters and comparison hashes describe the payload sent to the server.
         const records = parseTranscriptRecords(raw);
-        const gitBranch = extractGitBranchFromRecords(records);
+        const candidates = extractCwdCandidatesFromRecords(records);
+        const fallbackCwd = process.cwd();
+        const target = await resolveUploadTarget(
+          candidates.length ? candidates : [{ cwd: fallbackCwd, weight: 1 }],
+          candidates[0]?.cwd ?? fallbackCwd,
+        );
+        if (!target.allowed) {
+          process.stdout.write(
+            `${filePath}: ${skipMessageLines(target.candidatesSeen, target.skipReason).join("\n")}\n`,
+          );
+          continue;
+        }
+        const { cwd, repoId } = target;
+        const gitBranch = extractGitBranchFromRecords(records, cwd);
         const gitContext = cwd ? await resolveGitContext(cwd, gitBranch) : null;
 
         const conversionResult = convertClaudeCodeTranscript(records, {
@@ -213,7 +232,9 @@ async function discoverLocalTranscripts(projectsRoot: string): Promise<LocalTran
         }
 
         // Compute sha256 from the prepared upload transcript so local/remote comparisons stay aligned
-        const preparedTranscript = prepareUnifiedTranscriptForUpload(conversionResult.transcript);
+        const preparedTranscript = prepareUnifiedTranscriptForUpload(
+          stampResolvedRepoId(conversionResult.transcript, repoId),
+        );
         const unifiedJson = JSON.stringify(preparedTranscript);
         const sha256 = createHash("sha256").update(unifiedJson).digest("hex");
 
@@ -264,51 +285,4 @@ function parseTranscriptRecords(rawTranscript: string): Record<string, unknown>[
   }
 
   return records;
-}
-
-function extractCwdFromTranscript(rawTranscript: string): string | null {
-  const lines = rawTranscript.split(/\r?\n/);
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed) {
-      continue;
-    }
-
-    try {
-      const record = JSON.parse(trimmed) as Record<string, unknown>;
-      const cwd = record?.cwd;
-      if (typeof cwd === "string" && cwd.length > 0) {
-        return cwd;
-      }
-    } catch {
-      continue;
-    }
-  }
-  return null;
-}
-
-function extractGitBranchFromRecords(records: Record<string, unknown>[]): string | undefined {
-  for (const record of records) {
-    const gitBranch = typeof record.gitBranch === "string" ? record.gitBranch.trim() : "";
-    if (gitBranch) {
-      return gitBranch;
-    }
-  }
-  return undefined;
-}
-
-async function resolveRepoIdFromCwd(cwd: string | null): Promise<string | null> {
-  if (!cwd) {
-    return null;
-  }
-
-  if (!(await isDirectory(cwd))) {
-    return null;
-  }
-
-  try {
-    return getRepoMetadata(cwd).repoId;
-  } catch {
-    return null;
-  }
 }

--- a/packages/cli/src/commands/cline/upload.ts
+++ b/packages/cli/src/commands/cline/upload.ts
@@ -10,7 +10,7 @@ import { homedir } from "os";
 import { convertClineTranscript, type ClineMessage, type ClineTaskMetadata, type UploadBlob } from "@agentlogs/shared";
 import { LiteLLMPricingFetcher } from "@agentlogs/shared/pricing";
 import { resolveGitContext } from "@agentlogs/shared/claudecode";
-import { uploadUnifiedToAllEnvs } from "../../lib/perform-upload";
+import { skipMessageLines, uploadUnifiedToAllEnvs } from "../../lib/perform-upload";
 
 const CLINE_TASKS_DIR = join(homedir(), ".cline", "data", "tasks");
 
@@ -232,7 +232,9 @@ export async function clineUploadCommand(taskIdOrPath?: string): Promise<void> {
 
   // Handle results
   if (uploadResult.skipped) {
-    console.log("Skipped: Repository not in allowlist");
+    for (const line of skipMessageLines(uploadResult.candidatesSeen)) {
+      console.log(line);
+    }
     process.exit(0);
   }
 

--- a/packages/cli/src/commands/cline/upload.ts
+++ b/packages/cli/src/commands/cline/upload.ts
@@ -232,7 +232,7 @@ export async function clineUploadCommand(taskIdOrPath?: string): Promise<void> {
 
   // Handle results
   if (uploadResult.skipped) {
-    for (const line of skipMessageLines(uploadResult.candidatesSeen)) {
+    for (const line of skipMessageLines(uploadResult.candidatesSeen, uploadResult.skipReason)) {
       console.log(line);
     }
     process.exit(0);

--- a/packages/cli/src/commands/opencode/upload.ts
+++ b/packages/cli/src/commands/opencode/upload.ts
@@ -5,7 +5,7 @@ import type { OpenCodeExport } from "@agentlogs/shared";
 import { convertOpenCodeTranscript } from "@agentlogs/shared/opencode";
 import { LiteLLMPricingFetcher } from "@agentlogs/shared/pricing";
 import { resolveGitContext } from "@agentlogs/shared/claudecode";
-import { uploadUnifiedToAllEnvs } from "../../lib/perform-upload";
+import { skipMessageLines, uploadUnifiedToAllEnvs } from "../../lib/perform-upload";
 
 interface SessionReadResult {
   success: boolean;
@@ -148,7 +148,9 @@ export async function opencodeUploadCommand(sessionId: string): Promise<void> {
 
   // Exit if skipped due to allowlist
   if (uploadResult.skipped) {
-    console.log("Skipped: Repository not in allowlist");
+    for (const line of skipMessageLines(uploadResult.candidatesSeen)) {
+      console.log(line);
+    }
     process.exit(0);
   }
 

--- a/packages/cli/src/commands/opencode/upload.ts
+++ b/packages/cli/src/commands/opencode/upload.ts
@@ -148,7 +148,7 @@ export async function opencodeUploadCommand(sessionId: string): Promise<void> {
 
   // Exit if skipped due to allowlist
   if (uploadResult.skipped) {
-    for (const line of skipMessageLines(uploadResult.candidatesSeen)) {
+    for (const line of skipMessageLines(uploadResult.candidatesSeen, uploadResult.skipReason)) {
       console.log(line);
     }
     process.exit(0);

--- a/packages/cli/src/commands/pi/upload.ts
+++ b/packages/cli/src/commands/pi/upload.ts
@@ -10,7 +10,7 @@ import { homedir } from "os";
 import { convertPiTranscript, type PiSessionEntry, type PiSessionHeader, type UploadBlob } from "@agentlogs/shared";
 import { LiteLLMPricingFetcher } from "@agentlogs/shared/pricing";
 import { resolveGitContext } from "@agentlogs/shared/claudecode";
-import { uploadUnifiedToAllEnvs } from "../../lib/perform-upload";
+import { skipMessageLines, uploadUnifiedToAllEnvs } from "../../lib/perform-upload";
 
 const PI_SESSIONS_DIR = join(homedir(), ".pi", "agent", "sessions");
 
@@ -219,7 +219,9 @@ export async function piUploadCommand(sessionIdOrPath?: string): Promise<void> {
 
   // Handle results
   if (uploadResult.skipped) {
-    console.log("Skipped: Repository not in allowlist");
+    for (const line of skipMessageLines(uploadResult.candidatesSeen)) {
+      console.log(line);
+    }
     process.exit(0);
   }
 

--- a/packages/cli/src/commands/pi/upload.ts
+++ b/packages/cli/src/commands/pi/upload.ts
@@ -219,7 +219,7 @@ export async function piUploadCommand(sessionIdOrPath?: string): Promise<void> {
 
   // Handle results
   if (uploadResult.skipped) {
-    for (const line of skipMessageLines(uploadResult.candidatesSeen)) {
+    for (const line of skipMessageLines(uploadResult.candidatesSeen, uploadResult.skipReason)) {
       console.log(line);
     }
     process.exit(0);

--- a/packages/cli/src/commands/upload.ts
+++ b/packages/cli/src/commands/upload.ts
@@ -8,7 +8,12 @@ import { convertPiTranscript, type PiSessionEntry, type PiSessionHeader } from "
 import { LiteLLMPricingFetcher } from "@agentlogs/shared/pricing";
 import { resolveGitContext } from "@agentlogs/shared/claudecode";
 import { pickTranscript } from "../tui/transcript-picker";
-import { performUploadToAllEnvs, uploadUnifiedToAllEnvs } from "../lib/perform-upload";
+import {
+  performUploadToAllEnvs,
+  skipMessageLines,
+  uploadUnifiedToAllEnvs,
+  type MultiEnvUploadResult,
+} from "../lib/perform-upload";
 import { getAuthenticatedEnvironments } from "../config";
 
 export interface UploadCommandOptions {
@@ -167,7 +172,7 @@ async function uploadOpenCodeTranscript(transcript: DiscoveredTranscript): Promi
 
   if (result.skipped) {
     console.log("");
-    console.log("Skipped: Repository not in allowlist");
+    process.stdout.write(`${skipMessageLines(result.candidatesSeen, result.skipReason).join("\n")}\n`);
     return true; // Skipped is not a failure
   }
 
@@ -258,7 +263,7 @@ async function uploadClineTranscript(transcript: DiscoveredTranscript): Promise<
 
   if (uploadResult.skipped) {
     console.log("");
-    console.log("Skipped: Repository not in allowlist");
+    process.stdout.write(`${skipMessageLines(uploadResult.candidatesSeen, uploadResult.skipReason).join("\n")}\n`);
     return true;
   }
 
@@ -329,7 +334,7 @@ async function uploadPiTranscript(transcript: DiscoveredTranscript): Promise<boo
 
   if (uploadResult.skipped) {
     console.log("");
-    console.log("Skipped: Repository not in allowlist");
+    process.stdout.write(`${skipMessageLines(uploadResult.candidatesSeen, uploadResult.skipReason).join("\n")}\n`);
     return true;
   }
 
@@ -413,23 +418,10 @@ function readOpenCodeSession(sessionId: string): OpenCodeExport | null {
   }
 }
 
-interface MultiEnvResult {
-  results: Array<{
-    envName: string;
-    baseURL: string;
-    success: boolean;
-    error?: string;
-  }>;
-  id: string;
-  sessionId: string;
-  anySuccess: boolean;
-  allSuccess: boolean;
-}
-
 /**
  * Print upload result and return success status
  */
-function printUploadResult(result: MultiEnvResult): boolean {
+function printUploadResult(result: MultiEnvUploadResult): boolean {
   if (result.anySuccess && result.id) {
     console.log("");
     console.log("Upload successful!");
@@ -444,7 +436,7 @@ function printUploadResult(result: MultiEnvResult): boolean {
     return true;
   } else if (result.results.length === 0) {
     console.log("");
-    console.log("Skipped: Repository not in allowlist");
+    process.stdout.write(`${skipMessageLines(result.candidatesSeen, result.skipReason).join("\n")}\n`);
     return true; // Skipped is not a failure
   } else {
     console.error("");

--- a/packages/cli/src/lib/fixtures/upload-runner.ts
+++ b/packages/cli/src/lib/fixtures/upload-runner.ts
@@ -1,0 +1,48 @@
+// Run each integration scenario in its own process: settings and discovery
+// cache the user directory at import time. Only storage location and pricing
+// are replaced; permission checks, conversion, commands and HTTP uploads are real.
+import { mock } from "bun:test";
+import * as os from "os";
+import type { TranscriptSource } from "@agentlogs/shared";
+
+const scenario = JSON.parse(process.argv[2]) as {
+  userDir: string;
+  mode: "single" | "all" | "hook" | "latest" | "sync";
+  source: TranscriptSource;
+  transcriptPath: string;
+  sessionId: string;
+  cwd: string;
+  repoFilter?: string;
+};
+mock.module("os", () => ({ ...os, homedir: () => scenario.userDir }));
+const { LiteLLMPricingFetcher } = await import("@agentlogs/shared/pricing");
+LiteLLMPricingFetcher.prototype.fetchModelPricing = async () => new Map();
+
+if (scenario.mode === "latest") {
+  const { interactiveUploadCommand } = await import("../../commands/upload");
+  await interactiveUploadCommand(undefined, { source: scenario.source, latest: true });
+} else if (scenario.mode === "sync") {
+  const { syncCommand } = await import("../../commands/claudecode/sync");
+  await syncCommand({ repoFilter: scenario.repoFilter });
+} else if (scenario.mode === "hook") {
+  if (scenario.source === "codex") {
+    const { hookCommand } = await import("../../commands/codex/hook");
+    await hookCommand();
+  } else {
+    const { hookCommand } = await import("../../commands/claudecode/hook");
+    await hookCommand();
+  }
+} else {
+  const { performUpload, performUploadToAllEnvs } = await import("../perform-upload");
+  const params = {
+    transcriptPath: scenario.transcriptPath,
+    sessionId: scenario.sessionId,
+    source: scenario.source,
+    cwdOverride: scenario.cwd,
+  };
+  const result =
+    scenario.mode === "single"
+      ? await performUpload(params, { serverUrl: process.env.AGENTLOGS_SERVER_URL, authToken: "integration-test" })
+      : await performUploadToAllEnvs(params);
+  process.stdout.write(JSON.stringify(result));
+}

--- a/packages/cli/src/lib/perform-upload.integration.test.ts
+++ b/packages/cli/src/lib/perform-upload.integration.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { dirname, join } from "path";
+import type { UnifiedTranscript } from "@agentlogs/shared/claudecode";
+
+type Source = "claude-code" | "codex";
+type Mode = "single" | "all" | "hook" | "latest" | "sync";
+const allowedRepo = "github.com/team/project";
+const privateRepo = "github.com/team/private";
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+  for (const cleanup of cleanups.splice(0).reverse()) cleanup();
+});
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "agentlogs-upload-"));
+  cleanups.push(() => rmSync(root, { recursive: true, force: true }));
+  const userDir = join(root, "user");
+  const configDir = join(userDir, ".config", "agentlogs");
+  mkdirSync(configDir, { recursive: true });
+  const settings = (allowMode = "allowlist") =>
+    writeFileSync(
+      join(configDir, "settings.json"),
+      JSON.stringify({
+        allowMode,
+        repos: { [allowedRepo]: { allow: true, visibility: "team" }, [privateRepo]: { allow: false } },
+      }),
+    );
+  settings();
+  function repo(name: string, remotes: Record<string, string>) {
+    const path = join(root, name);
+    mkdirSync(join(path, ".git"), { recursive: true });
+    writeFileSync(join(path, ".git", "HEAD"), "ref: refs/heads/integration\n");
+    writeFileSync(
+      join(path, ".git", "config"),
+      Object.entries(remotes)
+        .map(([name, id]) => `[remote "${name}"]\n  url = https://${id}.git\n`)
+        .join(""),
+    );
+    return path;
+  }
+  const uploads: Array<{ transcript: UnifiedTranscript; visibility: string | null; sha256: string }> = [];
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(request) {
+      const path = new URL(request.url).pathname;
+      if (path === "/api/transcripts" && request.method === "GET") {
+        return Response.json({
+          transcripts: uploads.map(({ transcript, sha256 }) => ({
+            transcriptId: transcript.id,
+            repoId: transcript.git?.repo,
+            sha256,
+          })),
+        });
+      }
+      if (path !== "/api/ingest" || request.method !== "POST")
+        return new Response("Unexpected request", { status: 404 });
+      const data = await request.formData();
+      const transcript = JSON.parse(String(data.get("unifiedTranscript"))) as UnifiedTranscript;
+      uploads.push({
+        transcript,
+        visibility: data.has("visibility") ? String(data.get("visibility")) : null,
+        sha256: String(data.get("sha256")),
+      });
+      return Response.json({ success: true, id: String(data.get("id")), transcriptId: transcript.id });
+    },
+  });
+  cleanups.push(() => server.stop(true));
+  async function run(source: Source, mode: Mode, cwds: string[], hint = cwds[0], repoFilter?: string) {
+    const sessionId = "00000000-0000-4000-8000-000000000043";
+    const timestamp = "2026-09-09T10:00:00.000Z";
+    const transcriptPath =
+      source === "claude-code"
+        ? join(userDir, ".claude", "projects", "integration", `${sessionId}.jsonl`)
+        : join(userDir, ".codex", "sessions", "2026", "09", "09", `rollout-${sessionId}.jsonl`);
+    mkdirSync(dirname(transcriptPath), { recursive: true });
+    const records =
+      source === "claude-code"
+        ? cwds.map((cwd, index) => ({
+            type: "user",
+            uuid: `message-${index}`,
+            sessionId,
+            timestamp,
+            cwd,
+            gitBranch: index === 0 ? "starting-directory-branch" : undefined,
+            message: { role: "user", content: `Check directory ${index}` },
+          }))
+        : [
+            {
+              type: "session_meta",
+              timestamp,
+              payload: { id: sessionId, cwd: cwds[0], timestamp, cli_version: "0.89.0" },
+            },
+            ...cwds.slice(1).map((cwd) => ({ type: "turn_context", timestamp, payload: { cwd } })),
+            { type: "event_msg", timestamp, payload: { type: "user_message", message: "Check these directories" } },
+            {
+              type: "response_item",
+              timestamp,
+              payload: {
+                type: "message",
+                role: "user",
+                content: [{ type: "input_text", text: "Check these directories" }],
+              },
+            },
+          ];
+    writeFileSync(transcriptPath, records.map((record) => JSON.stringify(record)).join("\n"));
+    const child = Bun.spawn(
+      [
+        process.execPath,
+        join(import.meta.dir, "fixtures", "upload-runner.ts"),
+        JSON.stringify({
+          userDir,
+          mode,
+          source,
+          transcriptPath,
+          sessionId,
+          cwd: hint,
+          repoFilter,
+        }),
+      ],
+      {
+        cwd: root,
+        env: {
+          PATH: process.env.PATH,
+          AGENTLOGS_SERVER_URL: server.url.origin,
+          AGENTLOGS_AUTH_TOKEN: "integration-test",
+        },
+        stdin: new Blob([
+          JSON.stringify({
+            hook_event_name: "Stop",
+            session_id: sessionId,
+            transcript_path: transcriptPath,
+            cwd: hint,
+          }),
+        ]),
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+    const [exitCode, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+    ]);
+    expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: "" });
+    return stdout;
+  }
+  return { root, userDir, settings, repo, uploads, run };
+}
+
+describe("upload permission and attribution through command entry points", () => {
+  for (const source of ["claude-code", "codex"] as const) {
+    for (const mode of ["single", "all", "hook", "latest"] as const) {
+      test(`${source} ${mode}: home-to-clone uploads to the allowed upstream`, async () => {
+        const f = fixture();
+        const clone = f.repo("fork", { origin: "github.com/person/fork", upstream: allowedRepo });
+        await f.run(source, mode, [f.userDir, clone, clone], f.userDir);
+        expect(f.uploads).toHaveLength(1);
+        expect(f.uploads[0].transcript.git).toMatchObject({ repo: allowedRepo, branch: "integration" });
+        expect(f.uploads[0].visibility).toBe("team");
+      });
+      test(`${source} ${mode}: a hint cannot hide a denied second root`, async () => {
+        const f = fixture();
+        f.settings("denylist");
+        const allowed = f.repo("allowed", { origin: allowedRepo });
+        const denied = f.repo("private", { origin: privateRepo });
+        const output = await f.run(source, mode, [allowed, denied], allowed);
+        expect(f.uploads).toHaveLength(0);
+        if (mode === "latest") expect(output).toContain("explicitly denied repository");
+      });
+    }
+    test(`${source}: an unresolved root cannot ride along with an allowed one`, async () => {
+      const f = fixture();
+      const allowed = f.repo("allowed", { origin: allowedRepo });
+      const unknown = f.repo("no-remote", {});
+      const output = await f.run(source, "all", [allowed, unknown], allowed);
+      expect(f.uploads).toHaveLength(0);
+      expect(JSON.parse(output).skipReason.reason).toBe("unresolved-root");
+    });
+    test(`${source}: an additional hook directory is permission-checked`, async () => {
+      const f = fixture();
+      const allowed = f.repo("allowed", { origin: allowedRepo });
+      const denied = f.repo("private", { origin: privateRepo });
+      await f.run(source, "hook", [allowed], denied);
+      expect(f.uploads).toHaveLength(0);
+    });
+  }
+  test("sync filters by selected upstream and does not re-upload unchanged data", async () => {
+    const f = fixture();
+    const clone = f.repo("fork", { origin: "github.com/person/fork", upstream: allowedRepo });
+    const cwds = [f.userDir, clone, clone];
+    const first = await f.run("claude-code", "sync", cwds, f.userDir, allowedRepo);
+    expect(first).toContain("1 uploaded");
+    expect(f.uploads).toHaveLength(1);
+    expect(f.uploads[0].transcript.git?.repo).toBe(allowedRepo);
+    const second = await f.run("claude-code", "sync", cwds, f.userDir, allowedRepo);
+    expect(second).toContain("All local transcripts are up to date.");
+    expect(f.uploads).toHaveLength(1);
+  });
+  test("sync excludes mixed allowed and unlisted roots before upload", async () => {
+    const f = fixture();
+    const allowed = f.repo("allowed", { origin: allowedRepo });
+    const unlisted = f.repo("private", { origin: privateRepo });
+    const output = await f.run("claude-code", "sync", [allowed, unlisted]);
+    expect(output).toContain("no allowlisted remote");
+    expect(f.uploads).toHaveLength(0);
+  });
+  test("a real linked Git worktree uploads using the shared upstream and its own branch", async () => {
+    const f = fixture();
+    const clone = join(f.root, "clone");
+    const worktree = join(f.root, "worktree");
+    function git(args: string[]) {
+      const result = Bun.spawnSync(["git", "-c", "core.fsmonitor=false", "-c", "commit.gpgsign=false", ...args], {
+        cwd: f.root,
+      });
+      expect({ code: result.exitCode, stderr: result.stderr.toString() }).toMatchObject({ code: 0 });
+    }
+    git(["init", "-b", "main", clone]);
+    git([
+      "-C",
+      clone,
+      "-c",
+      "user.name=Upload test",
+      "-c",
+      "user.email=upload@example.test",
+      "commit",
+      "--allow-empty",
+      "-m",
+      "Initial fixture",
+    ]);
+    git(["-C", clone, "remote", "add", "origin", "https://github.com/person/fork.git"]);
+    git(["-C", clone, "remote", "add", "upstream", `https://${allowedRepo}.git`]);
+    git(["-C", clone, "worktree", "add", "-b", "feature/integration", worktree]);
+    await f.run("codex", "latest", [f.userDir, worktree, worktree], f.userDir);
+    expect(f.uploads).toHaveLength(1);
+    expect(f.uploads[0].transcript.git).toMatchObject({ repo: allowedRepo, branch: "feature/integration" });
+  });
+});

--- a/packages/cli/src/lib/perform-upload.test.ts
+++ b/packages/cli/src/lib/perform-upload.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+import type { UnifiedTranscript } from "@agentlogs/shared/claudecode";
+import { extractCwdCandidatesFromRecords, skipMessageLines, stampResolvedRepoId } from "./perform-upload";
+
+function transcriptWithGit(repo: string | null): UnifiedTranscript {
+  // Only the git field is relevant here; cast through unknown to avoid building a
+  // full UnifiedTranscript for a pure-field test.
+  return {
+    git: repo === null ? null : { relativeCwd: ".", branch: "main", repo },
+  } as unknown as UnifiedTranscript;
+}
+
+describe("stampResolvedRepoId", () => {
+  it("overrides the embedded git.repo with the resolved repo (fork origin -> upstream)", () => {
+    const t = transcriptWithGit("github.com/me/repo-fork");
+    const stamped = stampResolvedRepoId(t, "github.com/acme/repo");
+    expect(stamped.git?.repo).toBe("github.com/acme/repo");
+    // Other git fields are preserved.
+    expect(stamped.git?.branch).toBe("main");
+    // Original is not mutated.
+    expect(t.git?.repo).toBe("github.com/me/repo-fork");
+  });
+
+  it("is a no-op when repoId is null", () => {
+    const t = transcriptWithGit("github.com/me/repo-fork");
+    expect(stampResolvedRepoId(t, null)).toBe(t);
+  });
+
+  it("is a no-op when there is no git context", () => {
+    const t = transcriptWithGit(null);
+    expect(stampResolvedRepoId(t, "github.com/acme/repo")).toBe(t);
+  });
+
+  it("is a no-op when the repo already matches", () => {
+    const t = transcriptWithGit("github.com/acme/repo");
+    expect(stampResolvedRepoId(t, "github.com/acme/repo")).toBe(t);
+  });
+});
+
+describe("skipMessageLines", () => {
+  it("lists the repos seen when present", () => {
+    const lines = skipMessageLines(["github.com/a/b", "github.com/c/d"]);
+    expect(lines.join("\n")).toContain("github.com/a/b, github.com/c/d");
+    expect(lines.some((l) => l.includes("agentlogs allow"))).toBe(true);
+  });
+
+  it("falls back to a no-repo message when nothing was seen", () => {
+    const lines = skipMessageLines([]);
+    expect(lines.join("\n")).toContain("no allowlisted git repository");
+  });
+
+  it("treats undefined like empty", () => {
+    expect(skipMessageLines(undefined)).toEqual(skipMessageLines([]));
+  });
+});
+
+describe("extractCwdCandidatesFromRecords", () => {
+  it("ranks cwds by frequency, ties broken by first appearance", () => {
+    const records = [
+      { cwd: "/home" },
+      { cwd: "/home" },
+      { cwd: "/repo" },
+      { cwd: "/repo" },
+      { cwd: "/repo" },
+      { other: 1 },
+      { cwd: "  " },
+    ];
+    expect(extractCwdCandidatesFromRecords(records)).toEqual([
+      { cwd: "/repo", weight: 3 },
+      { cwd: "/home", weight: 2 },
+    ]);
+  });
+
+  it("returns an empty list when no record carries a cwd", () => {
+    expect(extractCwdCandidatesFromRecords([{ a: 1 }, { b: 2 }])).toEqual([]);
+  });
+});

--- a/packages/cli/src/lib/perform-upload.test.ts
+++ b/packages/cli/src/lib/perform-upload.test.ts
@@ -26,9 +26,13 @@ describe("stampResolvedRepoId", () => {
     expect(stampResolvedRepoId(t, null)).toBe(t);
   });
 
-  it("is a no-op when there is no git context", () => {
+  it("attributes a resolved repo even when the source omitted git context", () => {
     const t = transcriptWithGit(null);
-    expect(stampResolvedRepoId(t, "github.com/acme/repo")).toBe(t);
+    expect(stampResolvedRepoId(t, "github.com/acme/repo").git).toEqual({
+      relativeCwd: null,
+      branch: null,
+      repo: "github.com/acme/repo",
+    });
   });
 
   it("is a no-op when the repo already matches", () => {
@@ -38,6 +42,24 @@ describe("stampResolvedRepoId", () => {
 });
 
 describe("skipMessageLines", () => {
+  it("reports the blocking root without claiming every repo is unlisted", () => {
+    const text = skipMessageLines(["github.com/allowed/repo", "github.com/private/repo"], {
+      reason: "unlisted-root",
+      gitRoot: "/private",
+    }).join("\n");
+    expect(text).toContain("a Git root with no allowlisted remote");
+    expect(text).toContain("Blocking Git root: /private");
+    expect(text).not.toContain("none of the repos");
+  });
+
+  it("distinguishes denied repositories from unresolved roots", () => {
+    expect(skipMessageLines([], { reason: "denied-repo", repoId: "github.com/secret/repo" }).join("\n")).toContain(
+      "explicitly denied",
+    );
+    expect(skipMessageLines([], { reason: "unresolved-root", gitRoot: "/private" }).join("\n")).toContain(
+      "no readable, supported remote",
+    );
+  });
   it("lists the repos seen when present", () => {
     const lines = skipMessageLines(["github.com/a/b", "github.com/c/d"]);
     expect(lines.join("\n")).toContain("github.com/a/b, github.com/c/d");
@@ -55,6 +77,24 @@ describe("skipMessageLines", () => {
 });
 
 describe("extractCwdCandidatesFromRecords", () => {
+  it("reads Codex session metadata and turn contexts, ignoring unrelated payloads", () => {
+    expect(
+      extractCwdCandidatesFromRecords(
+        [
+          { type: "session_meta", payload: { cwd: "/home" } },
+          { type: "turn_context", payload: { cwd: "/repo" } },
+          { type: "turn_context", payload: { cwd: "/repo/src/.." } },
+          { type: "response_item", payload: { cwd: "/ignored" } },
+          { type: "turn_context", payload: { cwd: 42 } },
+          { type: "turn_context", payload: null },
+        ],
+        "codex",
+      ),
+    ).toEqual([
+      { cwd: "/repo", weight: 2 },
+      { cwd: "/home", weight: 1 },
+    ]);
+  });
   it("ranks cwds by frequency, ties broken by first appearance", () => {
     const records = [
       { cwd: "/home" },

--- a/packages/cli/src/lib/perform-upload.ts
+++ b/packages/cli/src/lib/perform-upload.ts
@@ -12,7 +12,8 @@ import { uploadTranscript } from "@agentlogs/shared/upload";
 import type { UploadOptions } from "@agentlogs/shared/upload";
 import { getAuthenticatedEnvironments, type EnvName } from "../config";
 import { cacheTranscriptId, getOrCreateTranscriptId } from "../local-store";
-import { getRepoIdFromCwd, getRepoVisibility, isRepoAllowed } from "../settings";
+import { getRepoVisibility } from "../settings";
+import { type CwdCandidate, resolveUploadTarget } from "./repo-resolution";
 
 export interface PerformUploadParams {
   transcriptPath: string;
@@ -37,6 +38,8 @@ export interface PerformUploadResult {
   source: TranscriptSource;
   /** True if upload was skipped due to allowlist */
   skipped: boolean;
+  /** Distinct repo ids seen across the session's directories (populated on skip). */
+  candidatesSeen?: string[];
 }
 
 export function prepareUnifiedTranscriptForUpload(transcript: UnifiedTranscript): UnifiedTranscript {
@@ -46,6 +49,40 @@ export function prepareUnifiedTranscriptForUpload(transcript: UnifiedTranscript)
   });
   const fileRedactedTranscript = redactSensitiveFilesInTranscript(linkRewrittenTranscript);
   return redactSecretsDeep(fileRedactedTranscript);
+}
+
+/**
+ * Stamp the resolved repo id onto the transcript's embedded git context so the
+ * server attributes the upload to the selected (allowlisted) repo. Without this,
+ * a fork session keeps the origin-only repo derived during conversion, mis-
+ * attributing the upload to the personal fork instead of the canonical repo that
+ * passed the allowlist. Runs before link-rewriting/redaction so those use the
+ * selected repo too. No-op when there is no git context or the repo already matches.
+ */
+export function stampResolvedRepoId(transcript: UnifiedTranscript, repoId: string | null): UnifiedTranscript {
+  if (!repoId || !transcript.git || transcript.git.repo === repoId) {
+    return transcript;
+  }
+  return { ...transcript, git: { ...transcript.git, repo: repoId } };
+}
+
+/**
+ * Shared user-facing message lines for an allowlist-skipped upload, so every
+ * command (claude-code, opencode, cline, pi) reports the same explanation.
+ */
+export function skipMessageLines(candidatesSeen: string[] | undefined): string[] {
+  const seen = candidatesSeen ?? [];
+  if (seen.length > 0) {
+    return [
+      "Upload skipped: none of the repos this session worked in are allowlisted.",
+      `Repos seen: ${seen.join(", ")}`,
+      "Run `agentlogs allow` in the target clone to enable uploads for it.",
+    ];
+  }
+  return [
+    "Upload skipped: no allowlisted git repository was found among this session's directories.",
+    "Run `agentlogs allow` in the target clone to enable uploads for it.",
+  ];
 }
 
 /**
@@ -74,6 +111,21 @@ export interface UploadUnifiedResult {
   allSuccess: boolean;
   /** True if upload was skipped due to allowlist */
   skipped: boolean;
+  /** Distinct repo ids seen across the session's directories (populated on skip). */
+  candidatesSeen?: string[];
+}
+
+/**
+ * Build the weighted cwd candidate list for repo resolution. When an explicit
+ * cwd override is supplied, only that directory is considered.
+ */
+function cwdCandidatesForParams(params: PerformUploadParams, parsed: ParsedTranscriptFile): CwdCandidate[] {
+  const override = params.cwdOverride?.trim();
+  if (override) {
+    return [{ cwd: override, weight: 1 }];
+  }
+  const candidates = extractCwdCandidatesFromRecords(parsed.records);
+  return candidates.length > 0 ? candidates : [{ cwd: parsed.cwd, weight: 1 }];
 }
 
 /**
@@ -87,12 +139,13 @@ export async function performUpload(
   params: PerformUploadParams,
   options: UploadOptions = {},
 ): Promise<PerformUploadResult> {
-  // Parse file first (cheap) to get cwd for allowlist check
+  // Parse file first (cheap) to get cwd candidates for allowlist check
   const parsed = parseTranscriptFile(params);
 
-  // Check if repo is allowed before expensive conversion
-  const repoId = await getRepoIdFromCwd(parsed.cwd);
-  if (!isRepoAllowed(repoId)) {
+  // Resolve the best allowlisted repo across all of the session's directories
+  // (and all their remotes) before expensive conversion.
+  const target = await resolveUploadTarget(cwdCandidatesForParams(params, parsed), parsed.cwd);
+  if (!target.allowed) {
     return {
       success: false,
       eventCount: parsed.records.length,
@@ -103,13 +156,21 @@ export async function performUpload(
       sha256: "",
       source: params.source ?? "claude-code",
       skipped: true,
+      candidatesSeen: target.candidatesSeen,
     };
   }
+
+  // Attribute conversion + git context to the resolved repo's working directory.
+  parsed.cwd = target.cwd;
+  const repoId = target.repoId;
 
   // Now do expensive conversion (pass pre-parsed data)
   const converted = await convertTranscriptFile(params, parsed);
 
-  const preparedTranscript = prepareUnifiedTranscriptForUpload(converted.unifiedTranscript);
+  // Attribute the transcript to the resolved repo (not the origin-only repo from conversion).
+  const preparedTranscript = prepareUnifiedTranscriptForUpload(
+    stampResolvedRepoId(converted.unifiedTranscript, repoId),
+  );
 
   // Compute sha256 from prepared unified transcript
   const unifiedJson = JSON.stringify(preparedTranscript);
@@ -212,6 +273,25 @@ function extractCwdFromRecords(records: Record<string, unknown>[]): string | nul
   return null;
 }
 
+/**
+ * Collect every distinct cwd referenced by the transcript, weighted by how many
+ * records mention it. Ordered by descending weight, ties broken by first
+ * appearance. Used to attribute a session to the repo it actually worked in,
+ * rather than the first (often a home/orchestration) directory.
+ */
+export function extractCwdCandidatesFromRecords(records: Record<string, unknown>[]): CwdCandidate[] {
+  const counts = new Map<string, number>();
+  for (const record of records) {
+    const cwd = typeof record.cwd === "string" ? record.cwd.trim() : "";
+    if (cwd) {
+      counts.set(cwd, (counts.get(cwd) ?? 0) + 1);
+    }
+  }
+  // Map preserves insertion (first-appearance) order; a stable sort by descending
+  // weight therefore keeps first appearance as the tie-break.
+  return [...counts.entries()].map(([cwd, weight]) => ({ cwd, weight })).sort((a, b) => b.weight - a.weight);
+}
+
 function extractGitBranchFromRecords(records: Record<string, unknown>[]): string | undefined {
   for (const record of records) {
     const gitBranch = typeof record.gitBranch === "string" ? record.gitBranch.trim() : "";
@@ -240,6 +320,8 @@ export interface MultiEnvUploadResult {
   sessionId: string;
   anySuccess: boolean;
   allSuccess: boolean;
+  /** Distinct repo ids seen across the session's directories (populated on skip). */
+  candidatesSeen?: string[];
 }
 
 interface ParsedTranscriptFile {
@@ -370,12 +452,13 @@ export async function convertTranscriptFile(
  * Checks allowlist first, then converts and uploads.
  */
 export async function performUploadToAllEnvs(params: PerformUploadParams): Promise<MultiEnvUploadResult> {
-  // Parse file first (cheap) to get cwd for allowlist check
+  // Parse file first (cheap) to get cwd candidates for allowlist check
   const parsed = parseTranscriptFile(params);
 
-  // Check allowlist before expensive conversion
-  const repoId = await getRepoIdFromCwd(parsed.cwd);
-  if (!isRepoAllowed(repoId)) {
+  // Resolve the best allowlisted repo across all of the session's directories
+  // (and all their remotes) before expensive conversion.
+  const target = await resolveUploadTarget(cwdCandidatesForParams(params, parsed), parsed.cwd);
+  if (!target.allowed) {
     return {
       results: [],
       eventCount: parsed.records.length,
@@ -383,8 +466,12 @@ export async function performUploadToAllEnvs(params: PerformUploadParams): Promi
       sessionId: "",
       anySuccess: false,
       allSuccess: false,
+      candidatesSeen: target.candidatesSeen,
     };
   }
+
+  // Attribute conversion + git context to the resolved repo's working directory.
+  parsed.cwd = target.cwd;
 
   // Now do expensive conversion (pass pre-parsed data to avoid double-parsing)
   const converted = await convertTranscriptFile(params, parsed);
@@ -407,6 +494,7 @@ export async function performUploadToAllEnvs(params: PerformUploadParams): Promi
       sessionId: converted.sessionId,
       anySuccess: false,
       allSuccess: false,
+      candidatesSeen: result.candidatesSeen,
     };
   }
 
@@ -434,9 +522,10 @@ export async function performUploadToAllEnvs(params: PerformUploadParams): Promi
 export async function uploadUnifiedToAllEnvs(params: UploadUnifiedParams): Promise<UploadUnifiedResult> {
   const { unifiedTranscript, sessionId, cwd, blobs, visibility: visibilityOverride } = params;
 
-  // Check if repo is allowed for capture
-  const repoId = await getRepoIdFromCwd(cwd);
-  if (!isRepoAllowed(repoId)) {
+  // Check if repo is allowed for capture. Considers every remote of the cwd
+  // (not just origin), so fork-based workflows resolve to the canonical repo.
+  const target = await resolveUploadTarget([{ cwd, weight: 1 }], cwd);
+  if (!target.allowed) {
     return {
       results: [],
       id: "",
@@ -444,15 +533,18 @@ export async function uploadUnifiedToAllEnvs(params: UploadUnifiedParams): Promi
       anySuccess: false,
       allSuccess: false,
       skipped: true,
+      candidatesSeen: target.candidatesSeen,
     };
   }
+  const repoId = target.repoId;
 
   const authenticatedEnvs = await getAuthenticatedEnvironments();
   if (authenticatedEnvs.length === 0) {
     throw new Error("No authenticated environments found. Run `agentlogs login agentlogs.ai` first.");
   }
 
-  const preparedTranscript = prepareUnifiedTranscriptForUpload(unifiedTranscript);
+  // Attribute the transcript to the resolved repo (handles fork origin -> upstream).
+  const preparedTranscript = prepareUnifiedTranscriptForUpload(stampResolvedRepoId(unifiedTranscript, repoId));
 
   // Compute sha256 from prepared unified transcript
   const unifiedJson = JSON.stringify(preparedTranscript);

--- a/packages/cli/src/lib/perform-upload.ts
+++ b/packages/cli/src/lib/perform-upload.ts
@@ -13,11 +13,12 @@ import type { UploadOptions } from "@agentlogs/shared/upload";
 import { getAuthenticatedEnvironments, type EnvName } from "../config";
 import { cacheTranscriptId, getOrCreateTranscriptId } from "../local-store";
 import { getRepoVisibility } from "../settings";
-import { type CwdCandidate, resolveUploadTarget } from "./repo-resolution";
+import { type CwdCandidate, type UploadSkipReason, resolveUploadTarget } from "./repo-resolution";
 
 export interface PerformUploadParams {
   transcriptPath: string;
   sessionId?: string;
+  /** Discovery or hook directory hint; never replaces recorded directories in permission checks. */
   cwdOverride?: string;
   source?: TranscriptSource;
   /** Visibility override - if not set, server decides based on repo visibility */
@@ -40,6 +41,7 @@ export interface PerformUploadResult {
   skipped: boolean;
   /** Distinct repo ids seen across the session's directories (populated on skip). */
   candidatesSeen?: string[];
+  skipReason?: UploadSkipReason;
 }
 
 export function prepareUnifiedTranscriptForUpload(transcript: UnifiedTranscript): UnifiedTranscript {
@@ -57,31 +59,33 @@ export function prepareUnifiedTranscriptForUpload(transcript: UnifiedTranscript)
  * a fork session keeps the origin-only repo derived during conversion, mis-
  * attributing the upload to the personal fork instead of the canonical repo that
  * passed the allowlist. Runs before link-rewriting/redaction so those use the
- * selected repo too. No-op when there is no git context or the repo already matches.
+ * selected repo too, even when the source omitted git metadata.
  */
 export function stampResolvedRepoId(transcript: UnifiedTranscript, repoId: string | null): UnifiedTranscript {
-  if (!repoId || !transcript.git || transcript.git.repo === repoId) {
+  if (!repoId || transcript.git?.repo === repoId) {
     return transcript;
   }
-  return { ...transcript, git: { ...transcript.git, repo: repoId } };
+  return { ...transcript, git: { relativeCwd: null, branch: null, ...transcript.git, repo: repoId } };
 }
 
 /**
  * Shared user-facing message lines for an allowlist-skipped upload, so every
  * command (claude-code, opencode, cline, pi) reports the same explanation.
  */
-export function skipMessageLines(candidatesSeen: string[] | undefined): string[] {
+export function skipMessageLines(candidatesSeen: string[] | undefined, skipReason?: UploadSkipReason): string[] {
   const seen = candidatesSeen ?? [];
-  if (seen.length > 0) {
-    return [
-      "Upload skipped: none of the repos this session worked in are allowlisted.",
-      `Repos seen: ${seen.join(", ")}`,
-      "Run `agentlogs allow` in the target clone to enable uploads for it.",
-    ];
-  }
+  const explanations: Record<UploadSkipReason["reason"], string> = {
+    "denied-repo": "this session includes an explicitly denied repository.",
+    "unlisted-root": "this session includes a Git root with no allowlisted remote.",
+    "unresolved-root": "a Git root in this session has no readable, supported remote to check against the allowlist.",
+    "no-repo": "no allowlisted git repository was found among this session's directories.",
+  };
   return [
-    "Upload skipped: no allowlisted git repository was found among this session's directories.",
-    "Run `agentlogs allow` in the target clone to enable uploads for it.",
+    `Upload skipped: ${skipReason ? explanations[skipReason.reason] : seen.length ? "repository capture settings do not allow this session." : explanations["no-repo"]}`,
+    ...(skipReason?.gitRoot ? [`Blocking Git root: ${skipReason.gitRoot}`] : []),
+    ...(skipReason?.repoId ? [`Denied repository: ${skipReason.repoId}`] : []),
+    ...(seen.length > 0 ? [`Repos seen: ${seen.join(", ")}`] : []),
+    "Run `agentlogs settings` to review capture permissions. `agentlogs allow` applies to the current clone's origin remote.",
   ];
 }
 
@@ -113,18 +117,19 @@ export interface UploadUnifiedResult {
   skipped: boolean;
   /** Distinct repo ids seen across the session's directories (populated on skip). */
   candidatesSeen?: string[];
+  skipReason?: UploadSkipReason;
 }
 
 /**
- * Build the weighted cwd candidate list for repo resolution. When an explicit
- * cwd override is supplied, only that directory is considered.
+ * Recorded directories determine attribution. Include a discovery/hook hint as
+ * an additional permission candidate without increasing its attribution weight.
  */
 function cwdCandidatesForParams(params: PerformUploadParams, parsed: ParsedTranscriptFile): CwdCandidate[] {
   const override = params.cwdOverride?.trim();
-  if (override) {
-    return [{ cwd: override, weight: 1 }];
+  const candidates = extractCwdCandidatesFromRecords(parsed.records, params.source);
+  if (override && !candidates.some(({ cwd }) => cwd === resolve(override))) {
+    candidates.push({ cwd: resolve(override), weight: candidates.length > 0 ? 0 : 1 });
   }
-  const candidates = extractCwdCandidatesFromRecords(parsed.records);
   return candidates.length > 0 ? candidates : [{ cwd: parsed.cwd, weight: 1 }];
 }
 
@@ -157,6 +162,7 @@ export async function performUpload(
       source: params.source ?? "claude-code",
       skipped: true,
       candidatesSeen: target.candidatesSeen,
+      skipReason: target.skipReason,
     };
   }
 
@@ -263,14 +269,14 @@ export function resolveTranscriptPath(inputPath: string): string | null {
   return null;
 }
 
-function extractCwdFromRecords(records: Record<string, unknown>[]): string | null {
-  for (const record of records) {
-    const cwd = typeof record.cwd === "string" ? record.cwd.trim() : "";
-    if (cwd) {
-      return cwd;
-    }
+function recordCwd(record: Record<string, unknown>, source: TranscriptSource): string | null {
+  let cwd: unknown = record.cwd;
+  if (source === "codex") {
+    if (record.type !== "session_meta" && record.type !== "turn_context") return null;
+    const payload = record.payload;
+    cwd = payload && typeof payload === "object" ? (payload as Record<string, unknown>).cwd : undefined;
   }
-  return null;
+  return typeof cwd === "string" && cwd.trim() ? resolve(cwd.trim()) : null;
 }
 
 /**
@@ -279,10 +285,13 @@ function extractCwdFromRecords(records: Record<string, unknown>[]): string | nul
  * appearance. Used to attribute a session to the repo it actually worked in,
  * rather than the first (often a home/orchestration) directory.
  */
-export function extractCwdCandidatesFromRecords(records: Record<string, unknown>[]): CwdCandidate[] {
+export function extractCwdCandidatesFromRecords(
+  records: Record<string, unknown>[],
+  source: TranscriptSource = "claude-code",
+): CwdCandidate[] {
   const counts = new Map<string, number>();
   for (const record of records) {
-    const cwd = typeof record.cwd === "string" ? record.cwd.trim() : "";
+    const cwd = recordCwd(record, source);
     if (cwd) {
       counts.set(cwd, (counts.get(cwd) ?? 0) + 1);
     }
@@ -292,8 +301,10 @@ export function extractCwdCandidatesFromRecords(records: Record<string, unknown>
   return [...counts.entries()].map(([cwd, weight]) => ({ cwd, weight })).sort((a, b) => b.weight - a.weight);
 }
 
-function extractGitBranchFromRecords(records: Record<string, unknown>[]): string | undefined {
+export function extractGitBranchFromRecords(records: Record<string, unknown>[], cwd: string): string | undefined {
   for (const record of records) {
+    // A multi-repo session can record branches belonging to other roots.
+    if (recordCwd(record, "claude-code") !== resolve(cwd)) continue;
     const gitBranch = typeof record.gitBranch === "string" ? record.gitBranch.trim() : "";
     if (gitBranch) {
       return gitBranch;
@@ -322,6 +333,7 @@ export interface MultiEnvUploadResult {
   allSuccess: boolean;
   /** Distinct repo ids seen across the session's directories (populated on skip). */
   candidatesSeen?: string[];
+  skipReason?: UploadSkipReason;
 }
 
 interface ParsedTranscriptFile {
@@ -373,7 +385,7 @@ function parseTranscriptFile(params: PerformUploadParams): ParsedTranscriptFile 
   const cwd =
     params.cwdOverride && params.cwdOverride.trim().length > 0
       ? params.cwdOverride.trim()
-      : (extractCwdFromRecords(records) ?? process.cwd());
+      : (records.map((record) => recordCwd(record, params.source ?? "claude-code")).find(Boolean) ?? process.cwd());
 
   return { records, cwd, invalidLines };
 }
@@ -402,14 +414,14 @@ export async function convertTranscriptFile(
   const pricing = Object.fromEntries(pricingData);
 
   // Resolve git context from .git/config for accurate repo detection
-  const gitBranch = extractGitBranchFromRecords(parsed.records);
+  const gitBranch = extractGitBranchFromRecords(parsed.records, parsed.cwd);
   const gitContext = await resolveGitContext(parsed.cwd, gitBranch);
 
   const converterOptions = { pricing, gitContext };
 
   const conversionResult =
     source === "codex"
-      ? convertCodexTranscript(parsed.records, { pricing })
+      ? convertCodexTranscript(parsed.records, converterOptions)
       : convertClaudeCodeTranscript(parsed.records, converterOptions);
 
   if (!conversionResult) {
@@ -467,6 +479,7 @@ export async function performUploadToAllEnvs(params: PerformUploadParams): Promi
       anySuccess: false,
       allSuccess: false,
       candidatesSeen: target.candidatesSeen,
+      skipReason: target.skipReason,
     };
   }
 
@@ -476,7 +489,7 @@ export async function performUploadToAllEnvs(params: PerformUploadParams): Promi
   // Now do expensive conversion (pass pre-parsed data to avoid double-parsing)
   const converted = await convertTranscriptFile(params, parsed);
 
-  // Upload using shared logic (allowlist already checked, skip that check)
+  // Upload using shared logic, which also rechecks the selected root.
   const result = await uploadUnifiedToAllEnvs({
     unifiedTranscript: converted.unifiedTranscript,
     sessionId: converted.sessionId,
@@ -495,6 +508,7 @@ export async function performUploadToAllEnvs(params: PerformUploadParams): Promi
       anySuccess: false,
       allSuccess: false,
       candidatesSeen: result.candidatesSeen,
+      skipReason: result.skipReason,
     };
   }
 
@@ -534,6 +548,7 @@ export async function uploadUnifiedToAllEnvs(params: UploadUnifiedParams): Promi
       allSuccess: false,
       skipped: true,
       candidatesSeen: target.candidatesSeen,
+      skipReason: target.skipReason,
     };
   }
   const repoId = target.repoId;

--- a/packages/cli/src/lib/repo-resolution.fixtures.test.ts
+++ b/packages/cli/src/lib/repo-resolution.fixtures.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { extractCwdCandidatesFromRecords } from "./perform-upload";
+import { type CwdResolution, resolveUploadTarget } from "./repo-resolution";
+
+const FIXTURES = resolve(import.meta.dir, "../../../../fixtures/repo-resolution");
+
+function loadRecords(name: string): Record<string, unknown>[] {
+  const raw = readFileSync(resolve(FIXTURES, name), "utf8");
+  return raw
+    .split(/\r?\n/)
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+function stubResolve(map: Record<string, CwdResolution | null>) {
+  return async (cwd: string) => map[cwd] ?? null;
+}
+
+function allowlist(...allowed: string[]) {
+  const set = new Set(allowed);
+  return (repoId: string | null) => (repoId === null ? false : set.has(repoId));
+}
+
+describe("repo resolution over real transcript fixtures", () => {
+  it("home-then-clone: attributes to the allowlisted clone, not the home dir", async () => {
+    const records = loadRecords("home-then-clone.jsonl");
+    const candidates = extractCwdCandidatesFromRecords(records);
+    // Clone dir worked in 4x vs home 2x -> clone ranks first.
+    expect(candidates[0]?.cwd).toBe("/Users/me/Projects/repo");
+
+    const target = await resolveUploadTarget(candidates, "/Users/me", {
+      resolveCwd: stubResolve({
+        "/Users/me": null,
+        "/Users/me/Projects/repo": {
+          gitRoot: "/Users/me/Projects/repo",
+          repos: [{ repoId: "github.com/acme/repo", remote: "origin" }],
+        },
+      }),
+      isAllowed: allowlist("github.com/acme/repo"),
+    });
+
+    expect(target.allowed).toBe(true);
+    expect(target.repoId).toBe("github.com/acme/repo");
+    expect(target.cwd).toBe("/Users/me/Projects/repo");
+  });
+
+  it("fork-upstream: attributes to the allowlisted upstream remote of the fork clone", async () => {
+    const records = loadRecords("fork-upstream.jsonl");
+    const candidates = extractCwdCandidatesFromRecords(records);
+
+    const target = await resolveUploadTarget(candidates, "/Users/me/Projects/repo-fork", {
+      resolveCwd: stubResolve({
+        "/Users/me/Projects/repo-fork": {
+          gitRoot: "/Users/me/Projects/repo-fork",
+          repos: [
+            { repoId: "github.com/you/repo-fork", remote: "origin" },
+            { repoId: "github.com/acme/repo", remote: "upstream" },
+          ],
+        },
+      }),
+      isAllowed: allowlist("github.com/acme/repo"),
+    });
+
+    expect(target.allowed).toBe(true);
+    expect(target.repoId).toBe("github.com/acme/repo");
+  });
+});

--- a/packages/cli/src/lib/repo-resolution.test.ts
+++ b/packages/cli/src/lib/repo-resolution.test.ts
@@ -153,6 +153,46 @@ describe("resolveUploadTarget", () => {
     expect(target.candidatesSeen).toEqual(["github.com/you/repo-fork"]);
   });
 
+  it("allowlist: a non-allowlisted repo touched alongside an allowed one forces a skip", async () => {
+    const PRIVATE = "/Users/me/Projects/private";
+    const resolve = stubResolve({
+      [CLONE]: { gitRoot: CLONE, repos: [{ repoId: "github.com/acme/repo", remote: "origin" }] },
+      [PRIVATE]: { gitRoot: PRIVATE, repos: [{ repoId: "github.com/me/private", remote: "origin" }] },
+    });
+    const target = await resolveUploadTarget(
+      [
+        { cwd: CLONE, weight: 400 },
+        { cwd: PRIVATE, weight: 5 },
+      ],
+      CLONE,
+      { resolveCwd: resolve, isAllowed: allowlist("github.com/acme/repo") },
+    );
+    expect(target.allowed).toBe(false);
+    expect(target.candidatesSeen).toContain("github.com/me/private");
+  });
+
+  it("aggregates cwd weights by git root, not by hottest single directory", async () => {
+    const SRC = "/Users/me/Projects/repo/src";
+    const TESTS = "/Users/me/Projects/repo/tests";
+    const OTHER2 = "/Users/me/Projects/other";
+    const resolve = stubResolve({
+      [SRC]: { gitRoot: "/Users/me/Projects/repo", repos: [{ repoId: "github.com/acme/repo", remote: "origin" }] },
+      [TESTS]: { gitRoot: "/Users/me/Projects/repo", repos: [{ repoId: "github.com/acme/repo", remote: "origin" }] },
+      [OTHER2]: { gitRoot: OTHER2, repos: [{ repoId: "github.com/acme/other", remote: "origin" }] },
+    });
+    const target = await resolveUploadTarget(
+      [
+        { cwd: OTHER2, weight: 3 },
+        { cwd: SRC, weight: 2 },
+        { cwd: TESTS, weight: 2 },
+      ],
+      OTHER2,
+      { resolveCwd: resolve, isAllowed: allowlist("github.com/acme/repo", "github.com/acme/other") },
+    );
+    // repo (2 + 2 = 4) outranks other (3) despite other being the hottest single dir.
+    expect(target.repoId).toBe("github.com/acme/repo");
+  });
+
   it("dominant tie-break: higher-weight allowed cwd wins", async () => {
     const OTHER = "/Users/me/Projects/other";
     const resolve = stubResolve({

--- a/packages/cli/src/lib/repo-resolution.test.ts
+++ b/packages/cli/src/lib/repo-resolution.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  buildRepoCandidates,
+  createDefaultResolveCwd,
+  type CwdResolution,
+  resolveUploadTarget,
+  selectBestAllowedRepo,
+} from "./repo-resolution";
+
+/** Build a stub resolveCwd from a cwd -> CwdResolution map. */
+function stubResolve(map: Record<string, CwdResolution | null>) {
+  return async (cwd: string) => map[cwd] ?? null;
+}
+
+/** Allowlist predicate from an explicit set of allowed repo ids. */
+function allowlist(...allowed: string[]) {
+  const set = new Set(allowed);
+  return (repoId: string | null) => (repoId === null ? false : set.has(repoId));
+}
+
+/** Denylist predicate: everything allowed except the explicitly denied set (null allowed). */
+function denylist(...denied: string[]) {
+  const set = new Set(denied);
+  return (repoId: string | null) => (repoId === null ? true : !set.has(repoId));
+}
+
+const HOME = "/Users/me";
+const CLONE = "/Users/me/Projects/repo";
+const FORK = "/Users/me/Projects/repo-fork";
+
+describe("selectBestAllowedRepo", () => {
+  it("returns the first allowed candidate in priority order", () => {
+    const candidates = [
+      { repoId: "github.com/you/fork", cwd: FORK, gitRoot: FORK, remote: "origin", weight: 400 },
+      { repoId: "github.com/acme/repo", cwd: FORK, gitRoot: FORK, remote: "upstream", weight: 400 },
+    ];
+    expect(selectBestAllowedRepo(candidates, (id) => id === "github.com/acme/repo")?.repoId).toBe(
+      "github.com/acme/repo",
+    );
+  });
+
+  it("returns null when no candidate is allowed", () => {
+    const candidates = [{ repoId: "github.com/you/fork", cwd: FORK, gitRoot: FORK, remote: "origin", weight: 1 }];
+    expect(selectBestAllowedRepo(candidates, () => false)).toBeNull();
+  });
+});
+
+describe("buildRepoCandidates", () => {
+  it("flattens cwds x remotes preserving cwd order and origin-first within a cwd", async () => {
+    const resolve = stubResolve({
+      [CLONE]: { gitRoot: CLONE, repos: [{ repoId: "github.com/acme/repo", remote: "origin" }] },
+      [HOME]: null,
+    });
+    const candidates = await buildRepoCandidates(
+      [
+        { cwd: CLONE, weight: 400 },
+        { cwd: HOME, weight: 100 },
+      ],
+      resolve,
+    );
+    expect(candidates).toEqual([
+      { repoId: "github.com/acme/repo", cwd: CLONE, gitRoot: CLONE, remote: "origin", weight: 400 },
+    ]);
+  });
+});
+
+describe("resolveUploadTarget", () => {
+  it("home case: selects the allowlisted clone, not the non-repo home dir", async () => {
+    const resolve = stubResolve({
+      [HOME]: null,
+      [CLONE]: { gitRoot: CLONE, repos: [{ repoId: "github.com/acme/repo", remote: "origin" }] },
+    });
+    const target = await resolveUploadTarget(
+      [
+        { cwd: CLONE, weight: 400 },
+        { cwd: HOME, weight: 100 },
+      ],
+      HOME,
+      { resolveCwd: resolve, isAllowed: allowlist("github.com/acme/repo") },
+    );
+    expect(target).toEqual({
+      repoId: "github.com/acme/repo",
+      cwd: CLONE,
+      allowed: true,
+      candidatesSeen: ["github.com/acme/repo"],
+    });
+  });
+
+  it("fork case: selects the allowlisted upstream over the unlisted origin fork", async () => {
+    const resolve = stubResolve({
+      [FORK]: {
+        gitRoot: FORK,
+        repos: [
+          { repoId: "github.com/you/repo-fork", remote: "origin" },
+          { repoId: "github.com/acme/repo", remote: "upstream" },
+        ],
+      },
+    });
+    const target = await resolveUploadTarget([{ cwd: FORK, weight: 1 }], FORK, {
+      resolveCwd: resolve,
+      isAllowed: allowlist("github.com/acme/repo"),
+    });
+    expect(target.allowed).toBe(true);
+    expect(target.repoId).toBe("github.com/acme/repo");
+    expect(target.cwd).toBe(FORK);
+  });
+
+  it("common case: first cwd already an allowed repo resolves to that repo", async () => {
+    const resolve = stubResolve({
+      [CLONE]: { gitRoot: CLONE, repos: [{ repoId: "github.com/acme/repo", remote: "origin" }] },
+    });
+    const target = await resolveUploadTarget([{ cwd: CLONE, weight: 10 }], CLONE, {
+      resolveCwd: resolve,
+      isAllowed: denylist(),
+    });
+    expect(target).toEqual({
+      repoId: "github.com/acme/repo",
+      cwd: CLONE,
+      allowed: true,
+      candidatesSeen: ["github.com/acme/repo"],
+    });
+  });
+
+  it("denylist + no resolvable repo: uploads as unknown repo (null)", async () => {
+    const target = await resolveUploadTarget([{ cwd: HOME, weight: 5 }], HOME, {
+      resolveCwd: stubResolve({ [HOME]: null }),
+      isAllowed: denylist(),
+    });
+    expect(target).toEqual({ repoId: null, cwd: HOME, allowed: true, candidatesSeen: [] });
+  });
+
+  it("allowlist + no resolvable repo: skipped", async () => {
+    const target = await resolveUploadTarget([{ cwd: HOME, weight: 5 }], HOME, {
+      resolveCwd: stubResolve({ [HOME]: null }),
+      isAllowed: allowlist("github.com/acme/repo"),
+    });
+    expect(target.allowed).toBe(false);
+    expect(target.repoId).toBeNull();
+  });
+
+  it("allowlist + repos found but none allowed: skipped with candidates seen", async () => {
+    const resolve = stubResolve({
+      [FORK]: { gitRoot: FORK, repos: [{ repoId: "github.com/you/repo-fork", remote: "origin" }] },
+    });
+    const target = await resolveUploadTarget([{ cwd: FORK, weight: 3 }], FORK, {
+      resolveCwd: resolve,
+      isAllowed: allowlist("github.com/acme/repo"),
+    });
+    expect(target.allowed).toBe(false);
+    expect(target.candidatesSeen).toEqual(["github.com/you/repo-fork"]);
+  });
+
+  it("dominant tie-break: higher-weight allowed cwd wins", async () => {
+    const OTHER = "/Users/me/Projects/other";
+    const resolve = stubResolve({
+      [CLONE]: { gitRoot: CLONE, repos: [{ repoId: "github.com/acme/repo", remote: "origin" }] },
+      [OTHER]: { gitRoot: OTHER, repos: [{ repoId: "github.com/acme/other", remote: "origin" }] },
+    });
+    const target = await resolveUploadTarget(
+      [
+        { cwd: CLONE, weight: 400 },
+        { cwd: OTHER, weight: 50 },
+      ],
+      CLONE,
+      { resolveCwd: resolve, isAllowed: allowlist("github.com/acme/repo", "github.com/acme/other") },
+    );
+    expect(target.repoId).toBe("github.com/acme/repo");
+  });
+
+  it("denylist + explicitly denied repo found: skipped (respects the deny)", async () => {
+    const resolve = stubResolve({
+      [CLONE]: { gitRoot: CLONE, repos: [{ repoId: "github.com/acme/secret", remote: "origin" }] },
+    });
+    const target = await resolveUploadTarget([{ cwd: CLONE, weight: 9 }], CLONE, {
+      resolveCwd: resolve,
+      isAllowed: denylist("github.com/acme/secret"),
+    });
+    expect(target.allowed).toBe(false);
+    expect(target.repoId).toBe("github.com/acme/secret");
+  });
+
+  it("denylist deny-wins: a denied repo touched alongside an allowed repo forces a skip", async () => {
+    const DENIED = "/Users/me/Projects/secret";
+    const resolve = stubResolve({
+      [CLONE]: { gitRoot: CLONE, repos: [{ repoId: "github.com/acme/repo", remote: "origin" }] },
+      [DENIED]: { gitRoot: DENIED, repos: [{ repoId: "github.com/acme/secret", remote: "origin" }] },
+    });
+    // CLONE is the dominant (allowed) repo, but the session also touched a denied repo.
+    const target = await resolveUploadTarget(
+      [
+        { cwd: CLONE, weight: 500 },
+        { cwd: DENIED, weight: 5 },
+      ],
+      CLONE,
+      { resolveCwd: resolve, isAllowed: denylist("github.com/acme/secret") },
+    );
+    expect(target.allowed).toBe(false);
+    expect(target.candidatesSeen).toContain("github.com/acme/secret");
+  });
+
+  it("denylist + only allowed repos: uploads (deny-wins does not over-fire)", async () => {
+    const resolve = stubResolve({
+      [CLONE]: { gitRoot: CLONE, repos: [{ repoId: "github.com/acme/repo", remote: "origin" }] },
+    });
+    const target = await resolveUploadTarget([{ cwd: CLONE, weight: 5 }], CLONE, {
+      resolveCwd: resolve,
+      isAllowed: denylist("github.com/other/denied"),
+    });
+    expect(target.allowed).toBe(true);
+    expect(target.repoId).toBe("github.com/acme/repo");
+  });
+});
+
+describe("createDefaultResolveCwd (git-root memoization)", () => {
+  it("resolves distinct cwds under one repo to the same root, reading config once", async () => {
+    const root = mkdtempSync(join(tmpdir(), "agentlogs-resolve-"));
+    mkdirSync(join(root, ".git"), { recursive: true });
+    writeFileSync(join(root, ".git", "config"), `[remote "origin"]\n\turl = git@github.com:acme/repo.git\n`, "utf8");
+    const subA = join(root, "src");
+    const subB = join(root, "src", "lib");
+    mkdirSync(subB, { recursive: true });
+
+    const resolve = createDefaultResolveCwd();
+    const a = await resolve(subA);
+    expect(a?.repos).toEqual([{ repoId: "github.com/acme/repo", remote: "origin" }]);
+
+    // Remove the config; a memoized resolver keyed by git root must still return
+    // the cached repos for another cwd under the same root (proving no re-read).
+    rmSync(join(root, ".git", "config"));
+    const b = await resolve(subB);
+    expect(b?.gitRoot).toBe(a?.gitRoot);
+    expect(b?.repos).toEqual([{ repoId: "github.com/acme/repo", remote: "origin" }]);
+  });
+});

--- a/packages/cli/src/lib/repo-resolution.test.ts
+++ b/packages/cli/src/lib/repo-resolution.test.ts
@@ -68,6 +68,58 @@ describe("buildRepoCandidates", () => {
 });
 
 describe("resolveUploadTarget", () => {
+  it("retains a Git root without a resolvable remote in allowlist checks", async () => {
+    const target = await resolveUploadTarget(
+      [
+        { cwd: CLONE, weight: 100 },
+        { cwd: FORK, weight: 1 },
+      ],
+      CLONE,
+      {
+        resolveCwd: stubResolve({
+          [CLONE]: { gitRoot: CLONE, repos: [{ repoId: "github.com/acme/repo", remote: "origin" }] },
+          [FORK]: { gitRoot: FORK, repos: [] },
+        }),
+        isAllowed: allowlist("github.com/acme/repo"),
+      },
+    );
+    expect(target.allowed).toBe(false);
+    expect(target.skipReason).toEqual({ reason: "unresolved-root", gitRoot: FORK });
+  });
+
+  it.each(["missing-config", "unreadable-config", "invalid-gitdir"])(
+    "fails closed for %s beside an allowed repo",
+    async (kind) => {
+      const dir = mkdtempSync(join(tmpdir(), "agentlogs-unresolved-"));
+      try {
+        const allowed = join(dir, "allowed");
+        const unresolved = join(dir, "unresolved");
+        mkdirSync(join(allowed, ".git"), { recursive: true });
+        writeFileSync(join(allowed, ".git/config"), '[remote "origin"]\nurl = https://github.com/acme/repo.git\n');
+        mkdirSync(unresolved);
+        if (kind === "invalid-gitdir") {
+          writeFileSync(join(unresolved, ".git"), "invalid pointer");
+        } else {
+          mkdirSync(join(unresolved, ".git"));
+          if (kind === "unreadable-config") mkdirSync(join(unresolved, ".git/config"));
+        }
+        const target = await resolveUploadTarget(
+          [
+            { cwd: allowed, weight: 100 },
+            { cwd: unresolved, weight: 1 },
+          ],
+          allowed,
+          {
+            isAllowed: allowlist("github.com/acme/repo"),
+          },
+        );
+        expect(target.allowed).toBe(false);
+        expect(target.skipReason).toEqual({ reason: "unresolved-root", gitRoot: unresolved });
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  );
   it("home case: selects the allowlisted clone, not the non-repo home dir", async () => {
     const resolve = stubResolve({
       [HOME]: null,

--- a/packages/cli/src/lib/repo-resolution.ts
+++ b/packages/cli/src/lib/repo-resolution.ts
@@ -115,10 +115,14 @@ export function selectBestAllowedRepo(
  *   allowlist skips), exactly as `isRepoAllowed(null)` decides today.
  * - Repos found but all explicitly denied / not allowlisted -> skip.
  *
- * Deny wins in denylist mode: if the session touched ANY explicitly denied repo,
- * the upload is skipped even if it also touched an allowed repo. A transcript
- * carries every record's content regardless of which repo it is attributed to,
- * so a denied repo's content must never ride along under an allowed attribution.
+ * Both modes guard against leaking a non-captured repo's content, because a
+ * transcript carries every record regardless of which repo it is attributed to:
+ * - Deny wins (denylist): the session touched ANY explicitly denied repo -> skip.
+ * - Allowlist: EVERY touched git root must have an allowed repo -> otherwise skip,
+ *   so a session that also worked in a non-allowlisted repo doesn't ride along.
+ *
+ * Attribution is by dominant git ROOT (cwd weights aggregated per root, so a repo
+ * spread across several subdirectories isn't out-ranked by a single hotter dir).
  */
 export async function resolveUploadTarget(
   cwdCandidates: CwdCandidate[],
@@ -131,18 +135,54 @@ export async function resolveUploadTarget(
   const candidates = await buildRepoCandidates(cwdCandidates, resolveCwd);
   const candidatesSeen = [...new Set(candidates.map((candidate) => candidate.repoId))];
 
-  // Deny wins: in denylist mode, an explicitly denied repo among the candidates
-  // (isAllowed === false while unknown repos are allowed) forces a skip.
+  // Group candidates by git root. Weight is summed over DISTINCT cwds under the
+  // root (not per remote). allowedRepo is the first allowed repo in priority order
+  // (cwds by descending weight, origin-first within a cwd).
+  interface RootGroup {
+    weight: number;
+    order: number;
+    cwdsSeen: Set<string>;
+    firstRepo: RepoCandidate;
+    allowedRepo: RepoCandidate | null;
+  }
+  const rootGroups = new Map<string, RootGroup>();
+  let order = 0;
+  for (const candidate of candidates) {
+    let group = rootGroups.get(candidate.gitRoot);
+    if (!group) {
+      group = { weight: 0, order: order++, cwdsSeen: new Set(), firstRepo: candidate, allowedRepo: null };
+      rootGroups.set(candidate.gitRoot, group);
+    }
+    if (!group.cwdsSeen.has(candidate.cwd)) {
+      group.cwdsSeen.add(candidate.cwd);
+      group.weight += candidate.weight;
+    }
+    if (!group.allowedRepo && isAllowed(candidate.repoId)) {
+      group.allowedRepo = candidate;
+    }
+  }
+  const groups = [...rootGroups.values()];
+
+  // Deny wins: in denylist mode, an explicitly denied repo forces a skip.
   const denylistMode = isAllowed(null);
   if (denylistMode) {
     const denied = candidates.find((candidate) => !isAllowed(candidate.repoId));
     if (denied) {
       return { repoId: denied.repoId, cwd: denied.cwd, allowed: false, candidatesSeen };
     }
+  } else {
+    // Allowlist: every touched git root must resolve to an allowed repo.
+    const unlisted = groups.find((group) => !group.allowedRepo);
+    if (unlisted) {
+      return { repoId: unlisted.firstRepo.repoId, cwd: unlisted.firstRepo.cwd, allowed: false, candidatesSeen };
+    }
   }
 
-  const best = selectBestAllowedRepo(candidates, (repoId) => isAllowed(repoId));
-  if (best) {
+  // Pick the dominant allowed root (most aggregated weight; ties -> first seen).
+  const allowedGroups = groups.filter((group) => group.allowedRepo);
+  if (allowedGroups.length > 0) {
+    allowedGroups.sort((a, b) => b.weight - a.weight || a.order - b.order);
+    const best = allowedGroups[0].allowedRepo as RepoCandidate;
     return { repoId: best.repoId, cwd: best.cwd, allowed: true, candidatesSeen };
   }
 
@@ -151,7 +191,7 @@ export async function resolveUploadTarget(
     return { repoId: null, cwd: defaultCwd, allowed: isAllowed(null), candidatesSeen };
   }
 
-  // Repos were found but none are allowed (explicitly denied, or not allowlisted).
+  // Repos were found but none are allowed.
   const dominant = candidates[0];
   return { repoId: dominant.repoId, cwd: dominant.cwd, allowed: false, candidatesSeen };
 }

--- a/packages/cli/src/lib/repo-resolution.ts
+++ b/packages/cli/src/lib/repo-resolution.ts
@@ -1,0 +1,157 @@
+import { getRepoIdsFromGitRoot, locateGitRoot } from "@agentlogs/shared/git";
+import { createRepoAllowedChecker } from "../settings";
+
+export interface CwdCandidate {
+  cwd: string;
+  /** Number of records that referenced this cwd. */
+  weight: number;
+}
+
+export interface RepoCandidate {
+  repoId: string;
+  cwd: string;
+  gitRoot: string;
+  remote: string;
+  weight: number;
+}
+
+export interface ResolvedUploadTarget {
+  /** Repo id to attribute the upload to (null when no git repo was found). */
+  repoId: string | null;
+  /** Working directory to use for git-context resolution and downstream re-checks. */
+  cwd: string;
+  /** Whether the allowlist/denylist settings permit this upload. */
+  allowed: boolean;
+  /** Distinct repo ids seen across the session's directories (for messaging). */
+  candidatesSeen: string[];
+}
+
+export interface CwdResolution {
+  gitRoot: string;
+  repos: { repoId: string; remote: string }[];
+}
+
+export interface ResolveUploadTargetDeps {
+  /** Resolve a cwd to its git root + every repo id reachable from its remotes. */
+  resolveCwd?: (cwd: string) => Promise<CwdResolution | null>;
+  /** Allowlist predicate (defaults to settings-backed isRepoAllowed). */
+  isAllowed?: (repoId: string | null) => boolean;
+}
+
+/**
+ * Build a cwd resolver that memoizes by git root, so distinct cwds under the same
+ * repository (e.g. /repo, /repo/src, /repo/src/lib) read .git/config only once.
+ * Each resolveUploadTarget call gets a fresh resolver (no stale cross-call cache).
+ */
+export function createDefaultResolveCwd(): (cwd: string) => Promise<CwdResolution | null> {
+  const rootByCwd = new Map<string, string | null>();
+  const reposByRoot = new Map<string, { repoId: string; remote: string }[]>();
+
+  return async (cwd: string): Promise<CwdResolution | null> => {
+    let gitRoot = rootByCwd.get(cwd);
+    if (gitRoot === undefined) {
+      gitRoot = await locateGitRoot(cwd);
+      rootByCwd.set(cwd, gitRoot);
+    }
+    if (!gitRoot) {
+      return null;
+    }
+    let repos = reposByRoot.get(gitRoot);
+    if (!repos) {
+      repos = await getRepoIdsFromGitRoot(gitRoot);
+      reposByRoot.set(gitRoot, repos);
+    }
+    return { gitRoot, repos };
+  };
+}
+
+/**
+ * Build the flat list of repo candidates across all cwds x all remotes.
+ * Preserves the priority order of the input cwds (callers pass them sorted by
+ * descending weight); within a cwd, remotes are origin-first.
+ */
+export async function buildRepoCandidates(
+  cwdCandidates: CwdCandidate[],
+  resolveCwd: NonNullable<ResolveUploadTargetDeps["resolveCwd"]>,
+): Promise<RepoCandidate[]> {
+  const candidates: RepoCandidate[] = [];
+  for (const { cwd, weight } of cwdCandidates) {
+    const resolved = await resolveCwd(cwd);
+    if (!resolved) {
+      continue;
+    }
+    for (const { repoId, remote } of resolved.repos) {
+      candidates.push({ repoId, cwd, gitRoot: resolved.gitRoot, remote, weight });
+    }
+  }
+  return candidates;
+}
+
+/**
+ * Pure selection: the first allowed candidate in priority order. `candidates`
+ * must already be ordered by descending cwd weight, origin-first within a cwd
+ * (as buildRepoCandidates produces from weight-sorted cwds), so the first match
+ * is the dominant allowlisted repo.
+ */
+export function selectBestAllowedRepo(
+  candidates: RepoCandidate[],
+  isAllowed: (repoId: string) => boolean,
+): RepoCandidate | null {
+  return candidates.find((candidate) => isAllowed(candidate.repoId)) ?? null;
+}
+
+/**
+ * Decide which repo an upload should be attributed to, and whether it is allowed.
+ *
+ * Considers every working directory the session touched and every remote of each
+ * (not just the first cwd's `origin`). This is what lets a session launched from
+ * a home/personal directory — that pushed/PR'd to an allowlisted repo, possibly
+ * via an `upstream` remote on a fork — be attributed and uploaded instead of
+ * silently skipped.
+ *
+ * Behavior preserved for the common cases:
+ * - First cwd already resolves to an allowed repo -> same repo selected.
+ * - No git repo found anywhere -> "unknown repo" handling (denylist uploads,
+ *   allowlist skips), exactly as `isRepoAllowed(null)` decides today.
+ * - Repos found but all explicitly denied / not allowlisted -> skip.
+ *
+ * Deny wins in denylist mode: if the session touched ANY explicitly denied repo,
+ * the upload is skipped even if it also touched an allowed repo. A transcript
+ * carries every record's content regardless of which repo it is attributed to,
+ * so a denied repo's content must never ride along under an allowed attribution.
+ */
+export async function resolveUploadTarget(
+  cwdCandidates: CwdCandidate[],
+  defaultCwd: string,
+  deps: ResolveUploadTargetDeps = {},
+): Promise<ResolvedUploadTarget> {
+  const resolveCwd = deps.resolveCwd ?? createDefaultResolveCwd();
+  const isAllowed = deps.isAllowed ?? createRepoAllowedChecker();
+
+  const candidates = await buildRepoCandidates(cwdCandidates, resolveCwd);
+  const candidatesSeen = [...new Set(candidates.map((candidate) => candidate.repoId))];
+
+  // Deny wins: in denylist mode, an explicitly denied repo among the candidates
+  // (isAllowed === false while unknown repos are allowed) forces a skip.
+  const denylistMode = isAllowed(null);
+  if (denylistMode) {
+    const denied = candidates.find((candidate) => !isAllowed(candidate.repoId));
+    if (denied) {
+      return { repoId: denied.repoId, cwd: denied.cwd, allowed: false, candidatesSeen };
+    }
+  }
+
+  const best = selectBestAllowedRepo(candidates, (repoId) => isAllowed(repoId));
+  if (best) {
+    return { repoId: best.repoId, cwd: best.cwd, allowed: true, candidatesSeen };
+  }
+
+  if (candidates.length === 0) {
+    // No git repo found in any directory -> unknown-repo handling.
+    return { repoId: null, cwd: defaultCwd, allowed: isAllowed(null), candidatesSeen };
+  }
+
+  // Repos were found but none are allowed (explicitly denied, or not allowlisted).
+  const dominant = candidates[0];
+  return { repoId: dominant.repoId, cwd: dominant.cwd, allowed: false, candidatesSeen };
+}

--- a/packages/cli/src/lib/repo-resolution.ts
+++ b/packages/cli/src/lib/repo-resolution.ts
@@ -24,6 +24,13 @@ export interface ResolvedUploadTarget {
   allowed: boolean;
   /** Distinct repo ids seen across the session's directories (for messaging). */
   candidatesSeen: string[];
+  skipReason?: UploadSkipReason;
+}
+
+export interface UploadSkipReason {
+  reason: "denied-repo" | "unlisted-root" | "unresolved-root" | "no-repo";
+  gitRoot?: string;
+  repoId?: string;
 }
 
 export interface CwdResolution {
@@ -132,8 +139,7 @@ export async function resolveUploadTarget(
   const resolveCwd = deps.resolveCwd ?? createDefaultResolveCwd();
   const isAllowed = deps.isAllowed ?? createRepoAllowedChecker();
 
-  const candidates = await buildRepoCandidates(cwdCandidates, resolveCwd);
-  const candidatesSeen = [...new Set(candidates.map((candidate) => candidate.repoId))];
+  const candidates: RepoCandidate[] = [];
 
   // Group candidates by git root. Weight is summed over DISTINCT cwds under the
   // root (not per remote). allowedRepo is the first allowed repo in priority order
@@ -142,39 +148,67 @@ export async function resolveUploadTarget(
     weight: number;
     order: number;
     cwdsSeen: Set<string>;
-    firstRepo: RepoCandidate;
+    gitRoot: string;
+    cwd: string;
+    firstRepo: RepoCandidate | null;
     allowedRepo: RepoCandidate | null;
   }
   const rootGroups = new Map<string, RootGroup>();
   let order = 0;
-  for (const candidate of candidates) {
-    let group = rootGroups.get(candidate.gitRoot);
+  for (const { cwd, weight } of cwdCandidates) {
+    const resolved = await resolveCwd(cwd);
+    if (!resolved) continue;
+    let group = rootGroups.get(resolved.gitRoot);
     if (!group) {
-      group = { weight: 0, order: order++, cwdsSeen: new Set(), firstRepo: candidate, allowedRepo: null };
-      rootGroups.set(candidate.gitRoot, group);
+      group = {
+        weight: 0,
+        order: order++,
+        cwdsSeen: new Set(),
+        gitRoot: resolved.gitRoot,
+        cwd,
+        firstRepo: null,
+        allowedRepo: null,
+      };
+      rootGroups.set(resolved.gitRoot, group);
     }
-    if (!group.cwdsSeen.has(candidate.cwd)) {
-      group.cwdsSeen.add(candidate.cwd);
-      group.weight += candidate.weight;
+    if (!group.cwdsSeen.has(cwd)) {
+      group.cwdsSeen.add(cwd);
+      group.weight += weight;
     }
-    if (!group.allowedRepo && isAllowed(candidate.repoId)) {
-      group.allowedRepo = candidate;
+    for (const { repoId, remote } of resolved.repos) {
+      const candidate = { repoId, remote, cwd, weight, gitRoot: resolved.gitRoot };
+      candidates.push(candidate);
+      group.firstRepo ??= candidate;
+      if (!group.allowedRepo && isAllowed(repoId)) group.allowedRepo = candidate;
     }
   }
   const groups = [...rootGroups.values()];
+  const candidatesSeen = [...new Set(candidates.map((candidate) => candidate.repoId))];
 
   // Deny wins: in denylist mode, an explicitly denied repo forces a skip.
   const denylistMode = isAllowed(null);
   if (denylistMode) {
     const denied = candidates.find((candidate) => !isAllowed(candidate.repoId));
     if (denied) {
-      return { repoId: denied.repoId, cwd: denied.cwd, allowed: false, candidatesSeen };
+      return {
+        repoId: denied.repoId,
+        cwd: denied.cwd,
+        allowed: false,
+        candidatesSeen,
+        skipReason: { reason: "denied-repo", gitRoot: denied.gitRoot, repoId: denied.repoId },
+      };
     }
   } else {
     // Allowlist: every touched git root must resolve to an allowed repo.
     const unlisted = groups.find((group) => !group.allowedRepo);
     if (unlisted) {
-      return { repoId: unlisted.firstRepo.repoId, cwd: unlisted.firstRepo.cwd, allowed: false, candidatesSeen };
+      return {
+        repoId: unlisted.firstRepo?.repoId ?? null,
+        cwd: unlisted.cwd,
+        allowed: false,
+        candidatesSeen,
+        skipReason: { reason: unlisted.firstRepo ? "unlisted-root" : "unresolved-root", gitRoot: unlisted.gitRoot },
+      };
     }
   }
 
@@ -188,7 +222,13 @@ export async function resolveUploadTarget(
 
   if (candidates.length === 0) {
     // No git repo found in any directory -> unknown-repo handling.
-    return { repoId: null, cwd: defaultCwd, allowed: isAllowed(null), candidatesSeen };
+    return {
+      repoId: null,
+      cwd: defaultCwd,
+      allowed: denylistMode,
+      candidatesSeen,
+      ...(!denylistMode ? { skipReason: { reason: "no-repo" as const } } : {}),
+    };
   }
 
   // Repos were found but none are allowed.

--- a/packages/cli/src/lib/upload-jsonl.ts
+++ b/packages/cli/src/lib/upload-jsonl.ts
@@ -1,6 +1,6 @@
 import type { TranscriptSource } from "@agentlogs/shared";
 import { getAuthenticatedEnvironments } from "../config";
-import { performUploadToAllEnvs, resolveTranscriptPath } from "../lib/perform-upload";
+import { performUploadToAllEnvs, resolveTranscriptPath, skipMessageLines } from "../lib/perform-upload";
 
 export async function uploadCommand(transcriptArg: string, source: TranscriptSource = "claude-code"): Promise<void> {
   if (!transcriptArg) {
@@ -36,8 +36,9 @@ export async function uploadCommand(transcriptArg: string, source: TranscriptSou
     // Handle skipped uploads (repo not allowed)
     if (result.results.length === 0) {
       console.log("");
-      console.log("- Upload skipped (repo not allowed by allowlist)");
-      console.log("  Use `agentlogs allow` to enable uploads for this repo.");
+      for (const line of skipMessageLines(result.candidatesSeen)) {
+        console.log(`- ${line}`);
+      }
       return;
     }
 

--- a/packages/cli/src/lib/upload-jsonl.ts
+++ b/packages/cli/src/lib/upload-jsonl.ts
@@ -36,7 +36,7 @@ export async function uploadCommand(transcriptArg: string, source: TranscriptSou
     // Handle skipped uploads (repo not allowed)
     if (result.results.length === 0) {
       console.log("");
-      for (const line of skipMessageLines(result.candidatesSeen)) {
+      for (const line of skipMessageLines(result.candidatesSeen, result.skipReason)) {
         console.log(`- ${line}`);
       }
       return;

--- a/packages/cli/src/settings.ts
+++ b/packages/cli/src/settings.ts
@@ -89,17 +89,15 @@ export function writeSettings(settings: Settings): void {
 export { getRepoId as getRepoIdFromCwd } from "@agentlogs/shared/git";
 
 /**
- * Check if a repo is allowed for capture based on settings
+ * Pure allowlist check against an explicit settings snapshot.
  */
-export function isRepoAllowed(repoId: string | null): boolean {
+export function isRepoAllowedWithSettings(repoId: string | null, settings: Settings): boolean {
   if (!repoId) {
-    // If we can't determine the repo, use the default behavior
-    // In denylist mode, capture. In allowlist mode, don't capture.
-    const settings = readSettings();
+    // If we can't determine the repo, use the default behavior:
+    // denylist mode captures, allowlist mode does not.
     return settings.allowMode === "denylist";
   }
 
-  const settings = readSettings();
   const repoSettings = settings.repos[repoId];
 
   if (settings.allowMode === "denylist") {
@@ -115,6 +113,21 @@ export function isRepoAllowed(repoId: string | null): boolean {
     }
     return repoSettings.allow;
   }
+}
+
+/**
+ * Check if a repo is allowed for capture based on settings.
+ */
+export function isRepoAllowed(repoId: string | null): boolean {
+  return isRepoAllowedWithSettings(repoId, readSettings());
+}
+
+/**
+ * Build an allowlist predicate bound to a single settings snapshot, so callers
+ * that check many repo ids in one pass read settings.json once instead of per id.
+ */
+export function createRepoAllowedChecker(settings: Settings = readSettings()): (repoId: string | null) => boolean {
+  return (repoId) => isRepoAllowedWithSettings(repoId, settings);
 }
 
 /**

--- a/packages/shared/src/git.test.ts
+++ b/packages/shared/src/git.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  getRepoIdFromGitRoot,
+  getRepoIdsFromGitRoot,
+  parseGitRemoteUrl,
+  readGitRemotes,
+  readGitRemoteUrl,
+} from "./git";
+
+function makeRepo(config: string): string {
+  const root = mkdtempSync(join(tmpdir(), "agentlogs-git-"));
+  mkdirSync(join(root, ".git"), { recursive: true });
+  writeFileSync(join(root, ".git", "config"), config, "utf8");
+  return root;
+}
+
+const ORIGIN_ONLY = `[core]
+\trepositoryformatversion = 0
+[remote "origin"]
+\turl = git@github.com:owner/repo.git
+\tfetch = +refs/heads/*:refs/remotes/origin/*
+[branch "main"]
+\tremote = origin
+`;
+
+const FORK_WITH_UPSTREAM = `[remote "origin"]
+\turl = git@github.com:me/repo-fork.git
+\tfetch = +refs/heads/*:refs/remotes/origin/*
+[remote "upstream"]
+\turl = https://github.com/acme/repo.git
+\tfetch = +refs/heads/*:refs/remotes/upstream/*
+`;
+
+describe("parseGitRemoteUrl", () => {
+  it("parses SSH remotes", () => {
+    expect(parseGitRemoteUrl("git@github.com:owner/repo.git")).toBe("github.com/owner/repo");
+  });
+
+  it("parses HTTPS remotes with and without .git", () => {
+    expect(parseGitRemoteUrl("https://github.com/owner/repo.git")).toBe("github.com/owner/repo");
+    expect(parseGitRemoteUrl("https://github.com/owner/repo")).toBe("github.com/owner/repo");
+  });
+
+  it("returns null for unparseable input", () => {
+    expect(parseGitRemoteUrl("not-a-remote")).toBeNull();
+  });
+});
+
+describe("readGitRemotes", () => {
+  it("reads a single origin remote", async () => {
+    const root = makeRepo(ORIGIN_ONLY);
+    expect(await readGitRemotes(root)).toEqual([{ name: "origin", url: "git@github.com:owner/repo.git" }]);
+  });
+
+  it("reads multiple remotes with origin first", async () => {
+    const root = makeRepo(FORK_WITH_UPSTREAM);
+    const remotes = await readGitRemotes(root);
+    expect(remotes.map((r) => r.name)).toEqual(["origin", "upstream"]);
+    expect(remotes[1]?.url).toBe("https://github.com/acme/repo.git");
+  });
+
+  it("returns origin first even when it is declared after another remote", async () => {
+    const root = makeRepo(`[remote "upstream"]
+\turl = https://github.com/acme/repo.git
+[remote "origin"]
+\turl = git@github.com:me/repo-fork.git
+`);
+    expect((await readGitRemotes(root)).map((r) => r.name)).toEqual(["origin", "upstream"]);
+  });
+
+  it("returns an empty list when there are no remotes", async () => {
+    const root = makeRepo(`[core]\n\trepositoryformatversion = 0\n`);
+    expect(await readGitRemotes(root)).toEqual([]);
+  });
+
+  it("returns an empty list when .git/config is missing", async () => {
+    const root = mkdtempSync(join(tmpdir(), "agentlogs-git-empty-"));
+    expect(await readGitRemotes(root)).toEqual([]);
+  });
+});
+
+describe("readGitRemoteUrl (origin-only, backward compatible)", () => {
+  it("returns the origin url", async () => {
+    const root = makeRepo(FORK_WITH_UPSTREAM);
+    expect(await readGitRemoteUrl(root)).toBe("git@github.com:me/repo-fork.git");
+  });
+
+  it("returns null when there is no origin remote (no silent fallback to another remote)", async () => {
+    const root = makeRepo(`[remote "upstream"]\n\turl = https://github.com/acme/repo.git\n`);
+    expect(await readGitRemoteUrl(root)).toBeNull();
+  });
+});
+
+describe("getRepoIdFromGitRoot (origin)", () => {
+  it("resolves the origin repo id", async () => {
+    const root = makeRepo(ORIGIN_ONLY);
+    expect(await getRepoIdFromGitRoot(root)).toBe("github.com/owner/repo");
+  });
+});
+
+describe("getRepoIdsFromGitRoot (all remotes)", () => {
+  it("resolves a single origin repo id", async () => {
+    const root = makeRepo(ORIGIN_ONLY);
+    expect(await getRepoIdsFromGitRoot(root)).toEqual([{ repoId: "github.com/owner/repo", remote: "origin" }]);
+  });
+
+  it("resolves fork origin and canonical upstream, origin first", async () => {
+    const root = makeRepo(FORK_WITH_UPSTREAM);
+    expect(await getRepoIdsFromGitRoot(root)).toEqual([
+      { repoId: "github.com/me/repo-fork", remote: "origin" },
+      { repoId: "github.com/acme/repo", remote: "upstream" },
+    ]);
+  });
+
+  it("de-duplicates remotes pointing at the same repo", async () => {
+    const root = makeRepo(`[remote "origin"]
+\turl = git@github.com:acme/repo.git
+[remote "mirror"]
+\turl = https://github.com/acme/repo.git
+`);
+    expect(await getRepoIdsFromGitRoot(root)).toEqual([{ repoId: "github.com/acme/repo", remote: "origin" }]);
+  });
+});

--- a/packages/shared/src/git.test.ts
+++ b/packages/shared/src/git.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { mkdirSync, mkdtempSync, writeFileSync } from "fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import {
@@ -8,6 +8,7 @@ import {
   parseGitRemoteUrl,
   readGitRemotes,
   readGitRemoteUrl,
+  readGitBranch,
 } from "./git";
 
 function makeRepo(config: string): string {
@@ -50,6 +51,27 @@ describe("parseGitRemoteUrl", () => {
 });
 
 describe("readGitRemotes", () => {
+  it("uses a linked worktree's common config and its own HEAD", async () => {
+    const root = mkdtempSync(join(tmpdir(), "agentlogs-worktree-"));
+    try {
+      const checkout = join(root, "checkout");
+      const gitDirectory = join(root, "repo/.git/worktrees/checkout");
+      mkdirSync(checkout);
+      mkdirSync(gitDirectory, { recursive: true });
+      writeFileSync(join(checkout, ".git"), "gitdir: ../repo/.git/worktrees/checkout\n");
+      writeFileSync(join(gitDirectory, "commondir"), "../..\n");
+      writeFileSync(join(root, "repo/.git/config"), FORK_WITH_UPSTREAM);
+      writeFileSync(join(root, "repo/.git/HEAD"), "ref: refs/heads/main\n");
+      writeFileSync(join(gitDirectory, "HEAD"), "ref: refs/heads/feature\n");
+      expect(await getRepoIdsFromGitRoot(checkout)).toEqual([
+        { repoId: "github.com/me/repo-fork", remote: "origin" },
+        { repoId: "github.com/acme/repo", remote: "upstream" },
+      ]);
+      expect(await readGitBranch(checkout)).toBe("feature");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
   it("reads a single origin remote", async () => {
     const root = makeRepo(ORIGIN_ONLY);
     expect(await readGitRemotes(root)).toEqual([{ name: "origin", url: "git@github.com:owner/repo.git" }]);

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -53,28 +53,65 @@ export async function locateGitRoot(start: string): Promise<string | null> {
   }
 }
 
+export interface GitRemote {
+  name: string;
+  url: string;
+}
+
 /**
- * Read the origin remote URL from .git/config
+ * Read every remote (name + url) from .git/config.
+ * Remotes are returned with "origin" first (when present), then in file order.
  */
-export async function readGitRemoteUrl(repoRoot: string): Promise<string | null> {
+export async function readGitRemotes(repoRoot: string): Promise<GitRemote[]> {
   try {
     const configPath = path.join(repoRoot, ".git", "config");
     const configContent = await fs.readFile(configPath, "utf8");
 
-    // Look for remote "origin" url
-    const remoteMatch = configContent.match(/\[remote "origin"\]\s+url\s*=\s*(.+)/i);
-    if (!remoteMatch || !remoteMatch[1]) {
-      return null;
+    const remotes: GitRemote[] = [];
+    let currentRemote: string | null = null;
+
+    for (const rawLine of configContent.split(/\r?\n/)) {
+      const line = rawLine.trim();
+
+      const sectionMatch = line.match(/^\[remote "([^"]+)"\]/i);
+      if (sectionMatch && sectionMatch[1]) {
+        currentRemote = sectionMatch[1];
+        continue;
+      }
+      // Any other section header ends the current remote section.
+      if (line.startsWith("[")) {
+        currentRemote = null;
+        continue;
+      }
+
+      if (currentRemote) {
+        const urlMatch = line.match(/^url\s*=\s*(.+)$/i);
+        if (urlMatch && urlMatch[1]) {
+          remotes.push({ name: currentRemote, url: urlMatch[1].trim() });
+          currentRemote = null;
+        }
+      }
     }
 
-    return remoteMatch[1].trim();
+    // Stable order: origin first, everything else in file order.
+    return remotes.sort((a, b) => (a.name === "origin" ? -1 : 0) - (b.name === "origin" ? -1 : 0));
   } catch {
-    return null;
+    return [];
   }
 }
 
 /**
- * Get the repo ID from a git root directory.
+ * Read the origin remote URL from .git/config.
+ * Origin-only by design: returns null when there is no `origin` remote, matching
+ * the historical contract. Multi-remote resolution lives in getRepoIdsFromGitRoot.
+ */
+export async function readGitRemoteUrl(repoRoot: string): Promise<string | null> {
+  const remotes = await readGitRemotes(repoRoot);
+  return remotes.find((remote) => remote.name === "origin")?.url ?? null;
+}
+
+/**
+ * Get the repo ID from a git root directory (origin remote).
  * Returns format: "host/owner/repo" (e.g., "github.com/owner/repo")
  */
 export async function getRepoIdFromGitRoot(repoRoot: string): Promise<string | null> {
@@ -83,6 +120,31 @@ export async function getRepoIdFromGitRoot(repoRoot: string): Promise<string | n
     return null;
   }
   return parseGitRemoteUrl(url);
+}
+
+export interface RepoRemoteId {
+  repoId: string;
+  remote: string;
+}
+
+/**
+ * Get every repo ID reachable from a git root's remotes (not just origin).
+ * Useful for fork workflows where `origin` is a personal fork but `upstream`
+ * (or another remote) points at the canonical repo. Returns origin-first,
+ * de-duplicated by repoId.
+ */
+export async function getRepoIdsFromGitRoot(repoRoot: string): Promise<RepoRemoteId[]> {
+  const remotes = await readGitRemotes(repoRoot);
+  const seen = new Set<string>();
+  const result: RepoRemoteId[] = [];
+  for (const remote of remotes) {
+    const repoId = parseGitRemoteUrl(remote.url);
+    if (repoId && !seen.has(repoId)) {
+      seen.add(repoId);
+      result.push({ repoId, remote: remote.name });
+    }
+  }
+  return result;
 }
 
 /**

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -37,8 +37,10 @@ export async function locateGitRoot(start: string): Promise<string | null> {
       if (stats.isDirectory() || stats.isFile()) {
         return current;
       }
-    } catch {
-      // continue
+    } catch (error) {
+      // An unreadable .git must not disappear from capture permission checks.
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT" && code !== "ENOTDIR") return current;
     }
 
     if (current === root) {
@@ -58,13 +60,30 @@ export interface GitRemote {
   url: string;
 }
 
+async function resolveGitDirectory(repoRoot: string): Promise<string> {
+  const gitPath = path.join(repoRoot, ".git");
+  if (!(await fs.stat(gitPath)).isFile()) return gitPath;
+  const pointer = (await fs.readFile(gitPath, "utf8")).trim().match(/^gitdir:\s*(.+)$/);
+  if (!pointer) throw new Error("Invalid .git directory pointer");
+  return path.resolve(repoRoot, pointer[1]);
+}
+
 /**
- * Read every remote (name + url) from .git/config.
+ * Read every remote from the repository's shared config, including linked worktrees.
  * Remotes are returned with "origin" first (when present), then in file order.
  */
 export async function readGitRemotes(repoRoot: string): Promise<GitRemote[]> {
   try {
-    const configPath = path.join(repoRoot, ".git", "config");
+    const gitDirectory = await resolveGitDirectory(repoRoot);
+    let configDirectory = gitDirectory;
+    try {
+      const commonDirectory = (await fs.readFile(path.join(gitDirectory, "commondir"), "utf8")).trim();
+      if (!commonDirectory) return [];
+      configDirectory = path.resolve(gitDirectory, commonDirectory);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+    const configPath = path.join(configDirectory, "config");
     const configContent = await fs.readFile(configPath, "utf8");
 
     const remotes: GitRemote[] = [];
@@ -167,13 +186,12 @@ export async function getRepoId(cwd?: string): Promise<string | null> {
  */
 export async function readGitBranch(repoRoot: string, fallback?: string): Promise<string | null> {
   try {
-    const headPath = path.join(repoRoot, ".git", "HEAD");
+    const headPath = path.join(await resolveGitDirectory(repoRoot), "HEAD");
     const headContent = await fs.readFile(headPath, "utf8");
     const trimmed = headContent.trim();
     if (trimmed.startsWith("ref:")) {
       const ref = trimmed.slice(4).trim();
-      const parts = ref.split("/");
-      return parts[parts.length - 1] ?? fallback ?? null;
+      return ref.replace(/^refs\/heads\//, "") || fallback || null;
     }
     return trimmed || fallback || null;
   } catch {


### PR DESCRIPTION
## Problem

Repo attribution determines a transcript's repo by reading the **first `cwd`** in the transcript and only the **`origin`** remote of that directory. Two common workflows break as a result, and uploads are silently skipped in `allowlist` mode:

1. **Home / orchestration** — the agent is launched from `~` (or a monorepo root) and the real work happens in a clone reached later. The first `cwd` resolves to no repo, so the session is dropped even though it worked in (and pushed to) an allowlisted repo.
2. **Fork contribution** — the working clone's `origin` is a personal fork (not allowlisted), but `upstream` points at the allowlisted canonical repo the branch is PR'd into.

## Change

Attribution now considers **every `cwd` the session touched × every remote of each**, and selects the dominant **allowlisted** repo (allowed-first, then by `cwd` frequency). The resolved repo id is stamped onto the transcript's embedded git context so the server attributes the upload to the selected repo (handles `origin` fork → allowlisted `upstream`).

Behavior is preserved for existing cases:
- `denylist` (the default) still uploads unknown repos.
- The common case (first `cwd` already resolves to an allowed repo) is unchanged.
- No new subprocess spawns and no network calls in the hot path — git identity is still read from `.git/config` / `.git/HEAD`.

**Deny wins:** in `denylist` mode, a session that touched any explicitly *denied* repo is skipped even if it also touched an allowed one, so a denied repo's content can't ride along under an allowed attribution.

Skipped uploads now explain why, listing the repos the session worked in and pointing at `agentlogs allow`.

## Implementation

- `packages/shared/src/git.ts` — `readGitRemotes` + `getRepoIdsFromGitRoot` (all remotes, origin-first, de-duplicated). `readGitRemoteUrl` / `getRepoIdFromGitRoot` keep their origin-only contract.
- `packages/cli/src/lib/repo-resolution.ts` — pure `selectBestAllowedRepo` + injectable `resolveUploadTarget` (unit-testable without real git), git-root memoized so N cwds under one repo read `.git/config` once.
- Wired into `performUpload` / `performUploadToAllEnvs` / `uploadUnifiedToAllEnvs`; settings read once per resolution.

## Tests

`bun test` — 166 pass (13 new files/cases), covering: multi-remote parsing, all-cwd ranking, allowed-first + dominant selection, the home and fork cases, deny-wins, git-root memoization, the fork-attribution stamp, and the explanatory skip messages. Verified end-to-end against a real temp repo with `origin`=fork + `upstream`=allowlisted.

## Notes for reviewers

- **Pre-existing CI/typecheck error, not from this PR:** `packages/shared/src/pricing.ts:92` fails `tsgo` with `Property 'dispose' does not exist on type 'SymbolConstructor'` (a `lib`/target issue around `Symbol.dispose`). It reproduces on a clean checkout of `main` with the pinned toolchain and is unrelated to these changes — flagging so it isn't attributed here.
- **Deferred follow-ups** (kept out to keep this PR focused): applying the same multi-remote resolution to the live **hooks** and the **`allow`** command (so fork sessions also resolve correctly at hook time), `candidatesSeen` logging in `sync` and the hook logger, and git **worktree** (`.git`-as-file) support. Happy to do these in a follow-up.
